### PR TITLE
Persist browser partitions

### DIFF
--- a/browser/src/page/browser-session.ts
+++ b/browser/src/page/browser-session.ts
@@ -26,7 +26,7 @@ export function configureBrowserSession(
   partition: string | null,
   onDownload: (progress: DownloadProgress) => void,
 ): Session {
-  const target = partition ? session.fromPartition(partition) : session.defaultSession;
+  const target = browserSession(partition);
   if (configured.has(target)) return target;
   configured.add(target);
 
@@ -64,6 +64,14 @@ export function configureBrowserSession(
   });
 
   return target;
+}
+
+export function browserSession(partition: string | null): Session {
+  return partition ? session.fromPartition(persistentPartition(partition)) : session.defaultSession;
+}
+
+function persistentPartition(partition: string): string {
+  return partition.startsWith("persist:") ? partition : `persist:${partition}`;
 }
 
 function requestedDirectory(url: string): string | null {

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -7,7 +7,7 @@ import type { EngineKeyEvent, PixelRoot, Surface } from "pixel-react";
 import { detectBackend, reportedPixelUnit } from "pixel-terminals";
 import type { Backend } from "pixel-terminals";
 
-import { configureBrowserSession } from "../page/browser-session";
+import { browserSession, configureBrowserSession } from "../page/browser-session";
 import type { DownloadProgress } from "../page/browser-session";
 import { BrowserController } from "../page/controller";
 import { initialBrowserState } from "../page/types";
@@ -325,6 +325,9 @@ class Session {
     this.shuttingDown = true;
     try {
       this.root?.setPointerShape("text");
+    } catch { }
+    try {
+      browserSession(this.partition).flushStorageData();
     } catch { }
     this.registry?.dispose();
     this.registry = null;


### PR DESCRIPTION
## Summary
- Store named browser partitions as persistent Electron partitions
- Flush browser session storage before destroying tab windows

## Test
- corepack pnpm --filter terminal-browser typecheck