### PR TITLE
Implement upgrade sub command

### DIFF
--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -45,6 +45,14 @@ browser from drawing in them. Editors built on vscode ship with terminal images
 switched off, so this turns "terminal.integrated.enableImages" on in each one.
 `,
   },
+  upgrade: {
+    summary: "Upgrade to the latest release",
+    usage: "terminal-browser upgrade",
+    body: `
+Checks this install's release channel and installs the latest version. Does
+nothing when already up to date.
+`,
+  },
   action: {
     summary: "Use the open browser through the agent-browser CLI",
     usage: "terminal-browser action [selectors] -- <command>",
@@ -84,6 +92,7 @@ Usage: terminal-browser [url] [options]
 ${lines.join("\n")}
 
 terminal-browser <command> --help for one command's options
+terminal-browser --version prints the installed version
 `);
 }
 

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -22,6 +22,7 @@ import { locate, recordKey, reusable } from "./instances";
 import { lsCommand } from "./ls";
 import { instances } from "./registry";
 import type { InstanceRecord } from "./registry";
+import { installedVersion, upgradeCommand } from "./upgrade";
 
 const DIST_ROOT = process.env.TERMINAL_BROWSER_DIST_ROOT ?? null;
 delete process.env.ELECTRON_RUN_AS_NODE;
@@ -429,6 +430,10 @@ async function main(): Promise<number> {
     process.stdout.write(rootHelp());
     return 0;
   }
+  if (command === "--version" || command === "-v") {
+    process.stdout.write(`terminal-browser ${installedVersion() ?? "dev"}\n`);
+    return 0;
+  }
   if (command === "help") return helpCommand(args[0]);
   if (asksForHelp(args)) {
     const help = commandHelp(command);
@@ -448,6 +453,7 @@ async function main(): Promise<number> {
     return 0;
   }
   if (command === "setup") return setupCommand();
+  if (command === "upgrade") return upgradeCommand();
   if (command === "action") {
     const { own, passthrough } = splitPassthrough(args);
     const options = {

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+import { instances } from "./registry";
+import type { InstanceRecord } from "./registry";
+
+const RELEASE_ORIGIN = process.env.TERMINAL_BROWSER_RELEASE_ORIGIN ?? "https://terminal-browser.sh/install";
+
+interface Latest {
+  version: string;
+  install: string;
+}
+
+export function installedVersion(): string | null {
+  const root = process.env.TERMINAL_BROWSER_DIST_ROOT;
+  if (!root) return null;
+  try {
+    return fs.readFileSync(path.join(root, "VERSION"), "utf8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function installedChannel(): string {
+  const root = process.env.TERMINAL_BROWSER_DIST_ROOT;
+  if (!root) return "stable";
+  try {
+    return fs.readFileSync(path.join(root, "CHANNEL"), "utf8").trim() || "stable";
+  } catch {
+    return "stable";
+  }
+}
+
+async function fetchLatest(channel: string): Promise<Latest> {
+  const url = channel === "stable" ? `${RELEASE_ORIGIN}/latest.json` : `${RELEASE_ORIGIN}/${channel}/latest.json`;
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`release check failed (${response.status} from ${url})`);
+  const latest = (await response.json()) as Latest;
+  if (!latest.version || !latest.install) throw new Error(`release check failed (bad manifest from ${url})`);
+  return latest;
+}
+
+function describeInstance(record: InstanceRecord): string {
+  const page = record.title && record.title !== record.url ? `${record.title}  ${record.url}` : record.url;
+  return `  ${record.key}  ${page}`;
+}
+
+async function confirmClose(version: string, open: InstanceRecord[]): Promise<boolean> {
+  process.stdout.write(`upgrading to ${version} closes these open browsers:\n`);
+  process.stdout.write(`${open.map(describeInstance).join("\n")}\n`);
+  const ask = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => {
+    ask.question("continue? [Y/n] ", resolve);
+    ask.on("close", () => resolve("n"));
+  });
+  ask.close();
+  return /^(y|yes|)$/i.test(answer.trim());
+}
+
+function runInstaller(url: string): Promise<number> {
+  const child = spawn("bash", ["-c", `curl -fsSL '${url}' | bash`], { stdio: "inherit" });
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code ?? 1));
+  });
+}
+
+export async function upgradeCommand(): Promise<number> {
+  const current = installedVersion();
+  if (!current) {
+    throw new Error("Could not perform upgrade: please file an issue https://github.com/zenbu-labs/terminal-browser/issues");
+  }
+  const latest = await fetchLatest(installedChannel());
+  if (latest.version === current) {
+    process.stdout.write(`already up to date (${current})\n`);
+    return 0;
+  }
+  const open = await instances();
+  if (open.length > 0 && process.stdin.isTTY && process.stdout.isTTY) {
+    if (!(await confirmClose(latest.version, open))) {
+      process.stdout.write("cancelled\n");
+      return 0;
+    }
+  }
+  return runInstaller(latest.install);
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -50,6 +50,7 @@ exec "$ROOT/electron/terminal-browser.app/Contents/MacOS/terminal-browser" "$ROO
 EOF
 chmod +x "$STAGE/bin/terminal-browser"
 echo "$VERSION" > "$STAGE/VERSION"
+echo "$CHANNEL" > "$STAGE/CHANNEL"
 
 TARBALL="$OUT/terminal-browser-darwin-arm64.tar.gz"
 tar -czf "$TARBALL" -C "$OUT" terminal-browser

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -23,12 +23,14 @@ $ terminal-browser help
 Usage: terminal-browser [url] [options]
        terminal-browser <command> [args]
 
-  open    Open the browser in a terminal pane
-  ls      List running browsers and their tabs
-  setup   Configure installed terminals so terminal-browser works best
-  action  Use the open browser through the agent-browser CLI
+  open     Open the browser in a terminal pane
+  ls       List running browsers and their tabs
+  setup    Configure installed terminals so terminal-browser works best
+  upgrade  Upgrade to the latest release
+  action   Use the open browser through the agent-browser CLI
 
 terminal-browser <command> --help for one command's options
+terminal-browser --version prints the installed version
 ```
 
 ```
@@ -69,6 +71,14 @@ Usage: terminal-browser setup
 Finds the terminals on this machine and fixes any settings that would keep the
 browser from drawing in them. Editors built on vscode ship with terminal images
 switched off, so this turns "terminal.integrated.enableImages" on in each one.
+```
+
+```
+$ terminal-browser upgrade --help
+Usage: terminal-browser upgrade
+
+Checks this install's release channel and installs the latest version. Does
+nothing when already up to date.
 ```
 
 ```


### PR DESCRIPTION
Adds the ability to upgrade terminal-browser from the command line

Upgrading will close the open browsers for the user, as we don't guarantee different terminal-browser versions running on the same machine will work if ran in parallel. This is not ideal since if you have a long running browser open, you have to be disrupted to upgrade, or you will just not upgrade.

In the future we can be more smart and allow multiple versions to run in parallel (would require allowing multiple versions to be installed, and making sure there is no shared state between versions), which would allow us to not force the user to quit open browsers when upgrading
