### PR TITLE
Don't turn mouse side buttons into clicks

### DIFF
--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -1699,6 +1699,11 @@ fn parse_sgr_mouse(params: &[u8], press: bool) -> Option<(MouseKind, MouseButton
     } else {
         MouseKind::Up
     };
+    // a mouse's side buttons arrive as 128 + button, and their low bits look
+    // exactly like a left or middle click
+    if b & 128 != 0 && kind != MouseKind::Move {
+        return None;
+    }
     Some((kind, button, mods, x, y))
 }
 
@@ -1920,6 +1925,21 @@ mod tests {
         );
         assert_eq!(parse_sgr_mouse(b"0;1;1", true), None);
         assert_eq!(parse_sgr_mouse(b"<0;0;1", true), None);
+        assert_eq!(
+            parse_sgr_mouse(b"<128;1;1", true),
+            None,
+            "the back side button is not a left click"
+        );
+        assert_eq!(
+            parse_sgr_mouse(b"<129;1;1", false),
+            None,
+            "the forward side button is not a middle click"
+        );
+        assert_eq!(
+            parse_sgr_mouse(b"<160;1;1", true).unwrap().0,
+            MouseKind::Move,
+            "motion still tracks while a side button is held"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Pressing a mouse side button clicks the web page.

The terminal reports which mouse button was pressed as a number. The left mouse button is 0, the middle mouse button is 1, and the right mouse button is 2. The mouse side buttons are sent as 128 and 129.

The code only read the lowest two bits of that number. For 128 those bits are 0, identical to the left mouse button. For 129 they are 1, identical to the middle mouse button. So a side button press reached the page as a genuine left click wherever the cursor sat, and could follow a link or press a button by accident.

Ghostty encodes buttons 8 and 9 on macOS as of 1.3.0, which is also the minimum version `detectBackend` accepts.

## Changes

- Ignore press and release for mouse buttons 8 to 11 in the SGR mouse parser.
- Keep motion reports, so the cursor still tracks while a side button is held.
- Add three cases to the existing `parses_sgr_mouse_events` test.

## Validation

- Compiled the parser in isolation. `parses_sgr_mouse_events` passes with the new cases.
- Swept all 256 button bytes, press and release, against the original function. Bytes 0 to 127 are identical; only 128 and above change.
- Confirmed the old code decodes `CSI <128;10;20 M` as a left button down.
- Not built end to end. No macOS available.
