### PR TITLE
Open local dev servers over http instead of guessing

### DIFF
--- a/browser/src/url.ts
+++ b/browser/src/url.ts
@@ -13,12 +13,28 @@ function localFile(input: string, cwd?: string): string | null {
   return fs.existsSync(absolute) ? absolute : null;
 }
 
+/** Hosts a dev server listens on, which a browser has to reach over http. */
+function servedLocally(host: string): boolean {
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "0.0.0.0" ||
+    host.endsWith(".localhost")
+  );
+}
+
+function barePort(input: string): string | null {
+  const port = Number(input);
+  return /^\d+$/.test(input) && port >= 1 && port <= 65535 ? input : null;
+}
+
 export function searchOrUrl(text: string, cwd?: string): string {
   const trimmed = text.trim();
   if (HAS_AUTHORITY.test(trimmed) || SCHEMES_WITHOUT_HOST.test(trimmed)) return trimmed;
   if (localFile(trimmed, cwd)) return trimmed;
   if (!trimmed.includes(" ") && trimmed.includes(".")) return trimmed;
   if (/^[\w-]+:\d+(\/.*)?$/.test(trimmed)) return trimmed;
+  if (servedLocally(trimmed.split(/[:/?#]/)[0].toLowerCase())) return trimmed;
   return `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
 }
 
@@ -32,9 +48,13 @@ export function normalizeUrl(value: string, cwd?: string): string {
   }
   const file = localFile(input, cwd);
   if (file) return pathToFileURL(file).toString();
+  // a bare port is a dev server; without this the url parser reads the digits
+  // as an ipv4 address, so `3000` would load https://0.0.11.184
+  const port = barePort(input);
+  if (port) return new URL(`http://localhost:${port}`).toString();
   if (/^[\w.-]+(?::\d+)?(?:\/.*)?$/.test(input)) {
     const host = input.split(/[:/]/)[0].toLowerCase();
-    const scheme = host === "localhost" || host === "127.0.0.1" ? "http" : "https";
+    const scheme = servedLocally(host) ? "http" : "https";
     return new URL(`${scheme}://${input}`).toString();
   }
   return `https://www.google.com/search?q=${encodeURIComponent(input)}`;


### PR DESCRIPTION
## Motivation

`terminal-browser open 3000` loads https://0.0.11.184.

The help text says you can pass a localhost port. It did not work. The code prefixed `https://` and asked the URL parser to read `https://3000`. The URL standard treats a bare number as a packed IPv4 address, so 3000 became 0.0.11.184. The browser silently opened an unrelated address instead of your dev server, with no error and no hint.

Three smaller cases are the same question:

- servers bound to 0.0.0.0 are opened over https and fail to connect
- `*.localhost` hosts are opened over https too
- typing plain localhost in the address bar runs a Google search

`normalizeUrl` is on the agent path as well, since `open-tab` normalizes the same way.

## Changes

- Map a bare port to `http://localhost:<port>`.
- Route the loopback forms through one `servedLocally` helper: localhost, 127.0.0.1, 0.0.0.0, and `*.localhost`.
- Recognize a plain local host in the address bar, so `localhost` and `localhost/admin` are not searches.
- Left LAN addresses like 192.168.1.50:3000 on https. Usually http dev servers, but that is a guess about someone else's network.

## Validation

- Diffed the old and new module over 46 inputs. 8 change in `normalizeUrl`, 2 in `searchOrUrl`, everything else identical.
- Swept every bare integer from 0 to 70000. 1 to 65535 map to `http://localhost:<n>`; everything outside keeps its old path.
- `example.com`, `192.168.1.50:3000`, `localhost.evil.com`, and the data/chrome/file schemes are unchanged.
- Both versions typecheck under the repo's strict settings.
- Not built end to end. No macOS available.
