### PR TITLE
Prefer agent specific skill

### DIFF
--- a/scripts/generate-skill.sh
+++ b/scripts/generate-skill.sh
@@ -26,11 +26,14 @@ COMMANDS="$(node -e 'process.stdout.write(require(process.argv[1]).helpTopics().
 } > "$TMP/reference.md"
 
 render() {
-  awk -v overlay="$2" '
+  awk -v overlay="$2" -v suffix="$3" '
+    /^---$/ { dashes++ }
+    dashes == 1 && /^description: / && suffix != "" { print $0 " " suffix; next }
     { print }
-    /^---$/ && ++dashes == 2 && overlay != "" {
+    dashes == 2 && /^---$/ && overlay != "" && !spliced {
       print ""
       while ((getline line < overlay) > 0) print line
+      spliced = 1
     }
   ' "$1"
 }
@@ -42,9 +45,13 @@ node -p "require('$MANIFEST').skills.map(s => s.name + ' ' + s.variants.join(','
     for variant in ${variants//,/ }; do
       overlay="$ROOT/skill/$name/overlays/$variant.md"
       [ -f "$overlay" ] || overlay=""
+      suffix=""
+      if [ "$variant" != default ]; then
+        suffix="If another $name skill is listed from a shared skills directory, use this one instead."
+      fi
       mkdir -p "$OUT/$variant/$name"
       {
-        render "$ROOT/skill/$name/SKILL.template.md" "$overlay"
+        render "$ROOT/skill/$name/SKILL.template.md" "$overlay" "$suffix"
         cat "$TMP/reference.md"
       } > "$OUT/$variant/$name/SKILL.md"
       echo "wrote $OUT/$variant/$name/SKILL.md"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,8 @@ LINKED=""
 while read -r kind name location variant; do
   [ "$kind" = agent ] || continue
   DIR="$HOME/$location"
-  [ -d "$DIR" ] || continue
+  [ -d "$(dirname "$DIR")" ] || continue
+  mkdir -p "$DIR"
   MADE=""
   while read -r skind skill; do
     [ "$skind" = skill ] || continue


### PR DESCRIPTION
There is nothing stopping an agent from not deduping the .agents skill and .<agent specific> skill, and then reading the .agents skill first, which is what codex does. Because we write agent specific instructions in the .<agent specific> skill, the agent will not see that instruction if it chooses the .agent skill

Solution:
Update the .<agent specific> skill to explicitly tell the agent to prefer this skill over the .agent skill
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->