### PR TITLE
Add a cmux backend

### DIFF
--- a/terminals/src/cmux.ts
+++ b/terminals/src/cmux.ts
@@ -1,0 +1,113 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { Backend, Pane, shellQuote } from "./shared";
+
+const run = promisify(execFile);
+
+interface TreeSurface {
+  ref: string;
+  type: string;
+  title: string | null;
+  here: boolean;
+}
+
+interface TreeNode {
+  ref: string;
+  workspaces?: TreeNode[];
+  panes?: TreeNode[];
+  surfaces?: TreeSurface[];
+}
+
+interface Tree {
+  windows?: TreeNode[];
+}
+
+interface CmuxPane extends Pane {
+  surface: string;
+}
+
+export function createCmux(env: NodeJS.ProcessEnv = process.env): Backend {
+  const bin = env.CMUX_BUNDLED_CLI_PATH ?? "cmux";
+
+  async function cmux(args: string[]): Promise<string> {
+    const { stdout } = await run(bin, args, {
+      env,
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: 8000,
+    });
+    return stdout;
+  }
+
+  // cmux nests surfaces under panes under workspaces; a workspace is what the
+  // rest of terminal-browser calls a tab.
+  async function list(): Promise<CmuxPane[]> {
+    const tree = JSON.parse(await cmux(["tree", "--all", "--json"])) as Tree;
+    const panes: CmuxPane[] = [];
+    for (const window of tree.windows ?? []) {
+      for (const workspace of window.workspaces ?? []) {
+        for (const pane of workspace.panes ?? []) {
+          for (const surface of pane.surfaces ?? []) {
+            if (surface.type !== "terminal") continue;
+            panes.push({
+              window: window.ref,
+              tab: workspace.ref,
+              pane: pane.ref,
+              surface: surface.ref,
+              title: surface.title ?? "",
+              self: surface.here,
+            });
+          }
+        }
+      }
+    }
+    return panes;
+  }
+
+  async function find(titleNeedle: string): Promise<CmuxPane | null> {
+    return (await list()).find((pane) => pane.title.includes(titleNeedle)) ?? null;
+  }
+
+  const backend: Backend = {
+    app: "cmux",
+    async panes() {
+      return list();
+    },
+    async listAll() {
+      return list();
+    },
+    async split(direction, command) {
+      const created = await cmux(["new-split", direction, "--focus", "true"]);
+      const surface = /surface:\d+/.exec(created)?.[0];
+      if (!surface) throw new Error(`cmux new-split reported no surface: ${created.trim()}`);
+      await cmux(["send", "--surface", surface, shellQuote(command)]);
+      await cmux(["send-key", "--surface", surface, "Enter"]);
+    },
+    async sendText(paneId, text) {
+      const target = (await list()).find((pane) => pane.pane === paneId);
+      if (!target) return false;
+      await cmux(["send", "--surface", target.surface, text]);
+      await cmux(["focus-pane", "--pane", target.pane]);
+      return true;
+    },
+    async focusPane(titleNeedle) {
+      const target = await find(titleNeedle);
+      if (!target) return false;
+      await cmux(["focus-pane", "--pane", target.pane]);
+      return true;
+    },
+    async focusSelf() {
+      const target = (await list()).find((pane) => pane.self);
+      if (!target) return false;
+      await cmux(["focus-pane", "--pane", target.pane]);
+      return true;
+    },
+    async closePane(titleNeedle) {
+      const target = await find(titleNeedle);
+      if (!target) return false;
+      await cmux(["close-surface", "--surface", target.surface]);
+      return true;
+    },
+  };
+  return backend;
+}

--- a/terminals/src/index.ts
+++ b/terminals/src/index.ts
@@ -1,3 +1,4 @@
+import { createCmux } from "./cmux";
 import { ghostty } from "./ghostty";
 import { createKitty } from "./kitty";
 import { createTmux } from "./tmux";
@@ -21,6 +22,9 @@ export {
 export function detectBackend(env: NodeJS.ProcessEnv = process.env): Backend {
   const term = env.TERM ?? "";
   if (env.TMUX) return createTmux(env);
+  // cmux embeds libghostty and so inherits TERM_PROGRAM=ghostty, but Ghostty.app
+  // cannot script its panes. Check it before the ghostty branch below.
+  if (env.CMUX_SURFACE_ID || env.CMUX_BUNDLE_ID) return createCmux(env);
   if (term.includes("ghostty") || env.TERM_PROGRAM === "ghostty" || env.GHOSTTY_RESOURCES_DIR) {
     if ((env.TERM_PROGRAM_VERSION?.localeCompare("1.3.0", undefined, { numeric: true }) ?? 0) < 0) throw new Error(`Ghostty ${env.TERM_PROGRAM_VERSION} does not support automation: upgrade to Ghostty 1.3.0 or newer.`);
     return ghostty;

--- a/terminals/src/shared.ts
+++ b/terminals/src/shared.ts
@@ -13,7 +13,7 @@ export interface Pane {
 }
 
 export interface Backend {
-  app: "ghostty" | "kitty" | "wezterm" | "tmux"
+  app: "ghostty" | "kitty" | "wezterm" | "tmux" | "cmux"
   panes(): Promise<Pane[]>;
   listAll(): Promise<Omit<Pane, "self">[]>;
   split(direction: Direction, command: string[], size?: number | null): Promise<void>;


### PR DESCRIPTION
Fixes #17.

## The problem

cmux embeds libghostty, so it legitimately sets `TERM_PROGRAM=ghostty` and `GHOSTTY_RESOURCES_DIR`. `detectBackend` reads those and hands back the Ghostty backend, which controls panes with `tell application "Ghostty"`. cmux is a different app (`com.cmuxterm.app`), so the marker is never found and `ls`, `open --split`, and `action` all fail with:

```
could not find this pane in Ghostty — something keeps rewriting the /dev/ttysNNN title
(busy TUI), or this shell is inside tmux (which drops the title marker unless set-titles is on)
```

Rendering already worked, since cmux speaks the kitty graphics protocol. Only pane control was missing.

### One correction to #17

That issue reports every `osascript` call failing with `-1728` because `Ghostty.app` is not installed. On a machine where **Ghostty.app is installed alongside cmux**, there is no `-1728` at all:

```
$ osascript -e 'tell application "Ghostty" to count windows'
1
```

AppleScript succeeds and returns Ghostty.app's real panes — the cmux pane is simply never among them. Same user-facing error, different mechanism.

That matters for the fix. Surfacing the swallowed `osascript` error (#17's suggestion 1) is still worth doing, but on its own it would not have helped here, because there is no error to surface. Only not treating `GHOSTTY_*` as proof that Ghostty.app owns the pane covers both cases.

## The change

`detectBackend` now checks `CMUX_SURFACE_ID` / `CMUX_BUNDLE_ID` before the ghostty branch, and `terminals/src/cmux.ts` drives panes through the `cmux` CLI. It follows the same shape as the wezterm and tmux backends.

Two things make it simpler than the AppleScript backends:

- `cmux tree --all --json` returns every surface with its title and a `here` flag on the calling surface, so `panes()` needs no `pixel-marker-*` title round-trip and no retry loop.
- The CLI is already there: `new-split`, `send`, `send-key`, `focus-pane`, `close-surface`.

cmux nests surfaces under panes under workspaces. A cmux workspace is what `Pane` calls a tab, which is what `inCurrentTab` wants, since `new-split` puts the browser in the caller's workspace.

Terminal-only surfaces are filtered out of the listing, so cmux's own browser and simulator surfaces are ignored.

## Tested

On cmux 0.64.22 (libghostty 1.3.2) + macOS 26.5.2, arm64, against v0.3.3's Electron with this branch's CLI bundle:

| | |
|---|---|
| `ls`, `ls --all` | pane refs correct, `(this tab)` correct |
| `open --split right`, `--split down` | pane opens, browser registers |
| `action -- snapshot / eval / click` | all work |
| `action` with two browsers open | disambiguation error lists both correctly |
| `closePane` | closes only the target surface |

`terminals` typechecks clean.

## Not covered

**`--size` is accepted and ignored.** cmux's `new-split` has no size argument, so it would have to go through `resizePane`. `applySplitSize` passes display points, while cmux's `resize-pane --amount` is tmux-compatible and takes cells. In testing, `cmux resize-pane -L --amount 10` returned `OK` without moving the divider, so I did not want to guess at the units and ship something that silently half-works. Left out deliberately; happy to add it in a follow-up if you know the intended semantics, or I can raise it with cmux.

**`zoomPane` is not implemented** — the cmux CLI has no pane zoom (only `browser zoom`). It is optional on `Backend`.

**Escapes in `split`.** `cmux send` interprets `\n`, `\r`, and `\t` in its payload and has no literal flag, unlike `tmux send-keys -l` and `wezterm --no-paste`. A path or URL containing a literal backslash-n would break the launch command. Rare enough that I left it, but it is a real edge and probably wants a cmux-side fix.

I use this setup daily and am happy to test revisions.
