### PR TITLE
Keep ls --all working when the pane cannot be placed

### DIFF
--- a/cli/src/ls.ts
+++ b/cli/src/ls.ts
@@ -1,6 +1,7 @@
-import type { Backend } from "pixel-terminals";
+import type { Backend, Pane } from "pixel-terminals";
 
-import { browsers, recordKey, targets } from "./instances";
+import { locate, recordKey, targets } from "./instances";
+import { instances } from "./registry";
 import type { Browser, TabTarget } from "./instances";
 
 interface Listed {
@@ -53,8 +54,20 @@ function render(list: Listed[]): string {
   return `${lines.join("\n")}\n`;
 }
 
+/** Listing every browser does not depend on knowing our own pane, so a shell we
+ * cannot place — sandboxed, tmux, ssh — still gets the list instead of an error. */
+async function paneList(backend: Backend, all: boolean): Promise<Pane[]> {
+  if (!all) return backend.panes();
+  try {
+    return await backend.panes();
+  } catch {
+    return (await backend.listAll()).map((pane) => ({ ...pane, self: false }));
+  }
+}
+
 export async function lsCommand(backend: Backend, all: boolean, json: boolean) {
-  const found = await browsers(backend);
+  const panes = await paneList(backend, all);
+  const found = locate(await instances(), panes);
   const scoped = all ? found : found.filter((browser) => browser.inCurrentTab);
   const list = await collect(scoped);
   if (!json) {
@@ -64,7 +77,6 @@ export async function lsCommand(backend: Backend, all: boolean, json: boolean) {
     }
     return;
   }
-  const panes = await backend.panes();
   const self = panes.find((pane) => pane.self);
   process.stdout.write(
     `${JSON.stringify(


### PR DESCRIPTION
## Motivation

`terminal-browser ls --all` fails in any shell whose pane we cannot place.

This showed up in the Codex report on Discord. After the split failed, Codex fell back to listing the running browsers and got this:

```
• Ran terminal-browser ls --all
  └ terminal-browser: no terminal tty found for this process
```

The split half is fixed. This half is not.

`lsCommand` calls `browsers()`, which calls `backend.panes()`. For Ghostty that runs `selfPane()`, which needs the caller's tty and a marker round trip to work out which pane we are sitting in. When that fails it throws, and `--all` throws with it.

But `--all` is documented as "Every browser, not just this terminal tab". It never needed to know our own pane. Knowing it only adds the `(this tab)` marker.

`backend.listAll()` already exists for exactly this. All four backends implement it. Nothing in the CLI has ever called it.

This is the agent's fallback path. When the automatic split does not work, listing what is already running is how an agent recovers and targets a browser with `--browser <key>`.

## Changes

- `ls --all` falls back to `backend.listAll()` when `panes()` throws.
- `ls` without `--all` is untouched and still reports the real error, since scoping to this tab genuinely needs our pane.
- Drop the second `backend.panes()` call in the `--json` path, which repeated the whole marker round trip.

## Validation

- Drove the real `paneList()` and `locate()` against a backend whose `panes()` throws the way Ghostty's does. 9 checks pass.
- With a placeable pane nothing moves: `ls` lists this tab only, `ls --all` lists both browsers, the `(this tab)` flag and `self` are still reported.
- With an unplaceable pane, `ls --all` lists both browsers, no browser claims this tab, and `self` is null.
- Plain `ls` in that same shell still throws `no terminal tty found for this process`.
- `cli/src/ls.ts` typechecks with 0 errors against the real `Backend` and `Pane` types under the repo's strict settings.
- Not built end to end. No macOS available, so I could not reproduce in a real Ghostty pane.
