### PR TITLE
Add explicit module type via package.json

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -11,3 +11,5 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
   --alias:pixel-store="$ROOT/store/src/index.ts" \
   --define:process.env.NODE_ENV='"production"' \
   --sourcemap --outfile="$2" --log-level=warning
+
+printf '{"type":"commonjs"}\n' > "$(dirname "$2")/package.json"


### PR DESCRIPTION
Currently when we execute our CLI with node it walks up the file system to find a package.json that declares a module type when resolving modules. Because we did not declare a package.json with a module type next to our script, a users package.json in their home directory can be read. If that module type is esm our script will error on install 

For example:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/760de8ca-02a9-4500-bea4-505e8af17278" />

We now explicitly write a package.json in the directory of our bundled cli

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->