### PR TITLE
Focus split when opened in cmux

### DIFF
--- a/terminals/src/terminals/cmux.ts
+++ b/terminals/src/terminals/cmux.ts
@@ -35,7 +35,7 @@ export const cmux: Detect = (env, run) => {
     name: "cmux",
     getCurrentPane: () => paneById(panes, env.CMUX_SURFACE_ID),
     async split({ from, direction, command }) {
-      const created = await asked(["new-split", direction, "--surface", from.id]);
+      const created = await asked(["new-split", direction, "--surface", from.id, "--focus", "true"]);
       const opened = created.surface_id ?? created.surface_ref;
       if (!opened) throw new Error("cmux opened a split but did not say which surface it is");
       await cmux(["send", "--surface", opened, "--", `${shellQuote(command)}\\n`]);

--- a/terminals/test/fixtures/cmux.json
+++ b/terminals/test/fixtures/cmux.json
@@ -10,8 +10,8 @@
     "cmux list-panes --json --id-format both": "{\"panes\":[{\"id\":\"aa000000-0000-4000-8000-00000000000a\",\"ref\":\"pane:1\",\"focused\":true,\"surface_count\":2},{\"id\":\"bb000000-0000-4000-8000-00000000000b\",\"ref\":\"pane:2\",\"focused\":false,\"surface_count\":1}]}",
     "cmux list-pane-surfaces --pane aa000000-0000-4000-8000-00000000000a --json --id-format both": "{\"surfaces\":[{\"id\":\"2f1a0c44-0000-4000-8000-000000000003\",\"ref\":\"surface:3\",\"selected\":true,\"title\":\"robby@Mac: ~\"},{\"id\":\"2f1a0c44-0000-4000-8000-000000000004\",\"ref\":\"surface:4\",\"selected\":false,\"title\":\"vim\"}]}",
     "cmux list-pane-surfaces --pane bb000000-0000-4000-8000-00000000000b --json --id-format both": "{\"surfaces\":[{\"id\":\"2f1a0c44-0000-4000-8000-000000000005\",\"ref\":\"surface:5\",\"selected\":true,\"title\":\"terminal-browser:90107-1\"}]}",
-    "cmux new-split right --surface 2f1a0c44-0000-4000-8000-000000000003 --json --id-format both": "{\"accepted\":true,\"surface_id\":\"2f1a0c44-0000-4000-8000-000000000009\",\"surface_ref\":\"surface:9\"}",
-    "cmux send --surface 2f1a0c44-0000-4000-8000-000000000009 -- terminal-browser open\\n": ""
+    "cmux send --surface 2f1a0c44-0000-4000-8000-000000000009 -- terminal-browser open\\n": "",
+    "cmux new-split right --surface 2f1a0c44-0000-4000-8000-000000000003 --focus true --json --id-format both": "{\"accepted\":true,\"surface_id\":\"2f1a0c44-0000-4000-8000-000000000009\",\"surface_ref\":\"surface:9\"}"
   },
   "expect": {
     "name": "cmux",
@@ -34,7 +34,7 @@
         "tty": null
       },
       "commands": [
-        "cmux new-split right --surface 2f1a0c44-0000-4000-8000-000000000003 --json --id-format both",
+        "cmux new-split right --surface 2f1a0c44-0000-4000-8000-000000000003 --focus true --json --id-format both",
         "cmux send --surface 2f1a0c44-0000-4000-8000-000000000009 -- terminal-browser open\\n"
       ]
     }


### PR DESCRIPTION
self explanatory
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->