### PR TITLE
Include native scroll helper in release build

### DIFF
--- a/engine/crates/pixel-core/src/native.rs
+++ b/engine/crates/pixel-core/src/native.rs
@@ -84,40 +84,37 @@ impl SharedHelper {
 
 static SHARED: Mutex<Option<SharedHelper>> = Mutex::new(None);
 
-fn helper_paths() -> impl Iterator<Item = String> {
+fn helper_path() -> Option<String> {
     std::env::var("NATIVE_SCROLL_HELPER")
         .ok()
-        .into_iter()
-        .chain(option_env!("NATIVE_SCROLL_HELPER").map(String::from))
+        .or_else(|| option_env!("NATIVE_SCROLL_HELPER").map(String::from))
 }
 
 fn spawn_helper() -> Option<SharedHelper> {
-    helper_paths().find_map(|path| {
-        let mut child = Command::new(&path)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .ok()?;
-        let stdout = child.stdout.take()?;
-        let stdin = child.stdin.take();
-        std::thread::spawn(move || {
-            read_lines(stdout);
-            let mut shared = SHARED.lock().unwrap();
-            if let Some(helper) = shared.as_mut() {
-                helper.dead = true;
-                helper.subscribers.clear();
-            }
-        });
-        Some(SharedHelper {
-            child,
-            stdin,
-            subscribers: Vec::new(),
-            scale: 2.0,
-            dead: false,
-            wanting: 0,
-            armed_at: None,
-        })
+    let mut child = Command::new(helper_path()?)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let stdout = child.stdout.take()?;
+    let stdin = child.stdin.take();
+    std::thread::spawn(move || {
+        read_lines(stdout);
+        let mut shared = SHARED.lock().unwrap();
+        if let Some(helper) = shared.as_mut() {
+            helper.dead = true;
+            helper.subscribers.clear();
+        }
+    });
+    Some(SharedHelper {
+        child,
+        stdin,
+        subscribers: Vec::new(),
+        scale: 2.0,
+        dead: false,
+        wanting: 0,
+        armed_at: None,
     })
 }
 

--- a/engine/crates/pixel-core/src/native.rs
+++ b/engine/crates/pixel-core/src/native.rs
@@ -84,12 +84,15 @@ impl SharedHelper {
 
 static SHARED: Mutex<Option<SharedHelper>> = Mutex::new(None);
 
-fn subscribe(waker: Option<Waker>) -> Option<Receiver<Msg>> {
-    let mut shared = SHARED.lock().unwrap();
-    if shared.is_none() {
-        let path = std::env::var("NATIVE_SCROLL_HELPER")
-            .ok()
-            .or_else(|| option_env!("NATIVE_SCROLL_HELPER").map(String::from))?;
+fn helper_paths() -> impl Iterator<Item = String> {
+    std::env::var("NATIVE_SCROLL_HELPER")
+        .ok()
+        .into_iter()
+        .chain(option_env!("NATIVE_SCROLL_HELPER").map(String::from))
+}
+
+fn spawn_helper() -> Option<SharedHelper> {
+    helper_paths().find_map(|path| {
         let mut child = Command::new(&path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -106,7 +109,7 @@ fn subscribe(waker: Option<Waker>) -> Option<Receiver<Msg>> {
                 helper.subscribers.clear();
             }
         });
-        *shared = Some(SharedHelper {
+        Some(SharedHelper {
             child,
             stdin,
             subscribers: Vec::new(),
@@ -114,7 +117,14 @@ fn subscribe(waker: Option<Waker>) -> Option<Receiver<Msg>> {
             dead: false,
             wanting: 0,
             armed_at: None,
-        });
+        })
+    })
+}
+
+fn subscribe(waker: Option<Waker>) -> Option<Receiver<Msg>> {
+    let mut shared = SHARED.lock().unwrap();
+    if shared.is_none() {
+        *shared = Some(spawn_helper()?);
     }
     let helper = shared.as_mut().unwrap();
     if helper.dead {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,6 +14,10 @@ mkdir -p "$STAGE"/{bin,cli/dist,browser/dist,browser/native,electron,agent-brows
 (cd "$ROOT/engine" && cargo build -p pixel-node --release)
 cp "${CARGO_TARGET_DIR:-$ROOT/engine/target}/release/libpixel_node.dylib" "$STAGE/browser/native/pixel.node"
 
+swiftc -O "$ROOT/engine/crates/pixel-core/native-scroll-helper.swift" \
+  -o "$STAGE/bin/native-scroll-helper"
+codesign --force --sign - --timestamp=none "$STAGE/bin/native-scroll-helper" 2>/dev/null || true
+
 AGENT_BROWSER_BIN="$("$ROOT/scripts/agent-browser.sh" --path)"
 cp "$AGENT_BROWSER_BIN" "$STAGE/agent-browser/bin/agent-browser"
 codesign --force --sign - --timestamp=none "$STAGE/agent-browser/bin/agent-browser" 2>/dev/null || true
@@ -46,6 +50,7 @@ cat > "$STAGE/bin/terminal-browser" <<'EOF'
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)"
 export TERMINAL_BROWSER_DIST_ROOT="$ROOT"
 export ELECTRON_RUN_AS_NODE=1
+export NATIVE_SCROLL_HELPER="$ROOT/bin/native-scroll-helper"
 exec "$ROOT/electron/terminal-browser.app/Contents/MacOS/terminal-browser" "$ROOT/cli/dist/main.js" "$@"
 EOF
 chmod +x "$STAGE/bin/terminal-browser"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,7 +14,7 @@ mkdir -p "$STAGE"/{bin,cli/dist,browser/dist,browser/native,electron,agent-brows
 (cd "$ROOT/engine" && cargo build -p pixel-node --release)
 cp "${CARGO_TARGET_DIR:-$ROOT/engine/target}/release/libpixel_node.dylib" "$STAGE/browser/native/pixel.node"
 
-swiftc -O "$ROOT/engine/crates/pixel-core/native-scroll-helper.swift" \
+swiftc -O -target arm64-apple-macos11 "$ROOT/engine/crates/pixel-core/native-scroll-helper.swift" \
   -o "$STAGE/bin/native-scroll-helper"
 codesign --force --sign - --timestamp=none "$STAGE/bin/native-scroll-helper" 2>/dev/null || true
 
@@ -50,7 +50,7 @@ cat > "$STAGE/bin/terminal-browser" <<'EOF'
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)"
 export TERMINAL_BROWSER_DIST_ROOT="$ROOT"
 export ELECTRON_RUN_AS_NODE=1
-export NATIVE_SCROLL_HELPER="$ROOT/bin/native-scroll-helper"
+export NATIVE_SCROLL_HELPER="${NATIVE_SCROLL_HELPER:-$ROOT/bin/native-scroll-helper}"
 exec "$ROOT/electron/terminal-browser.app/Contents/MacOS/terminal-browser" "$ROOT/cli/dist/main.js" "$@"
 EOF
 chmod +x "$STAGE/bin/terminal-browser"


### PR DESCRIPTION
Embarrassingly, we were not using our swift input helper in release builds and that caused scroll to be janky and not feel like a normal chrome browser, and caused trackpad gestures to not be tracked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->