### PR TITLE
Show toast to teach user how to quit

### DIFF
--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -355,7 +355,12 @@ class Session {
 
   private async copySelection() {
     const text = await this.focusedInput()?.selectionText();
-    if (text) this.root?.setClipboard(text);
+    if (!text) {
+      if (process.platform === "linux") this.showToast("ctrl+q to quit", "done");
+      return;
+    }
+    this.root?.setClipboard(text);
+    this.showToast("copied to clipboard", "done");
   }
 
 
@@ -879,7 +884,7 @@ class Session {
       this.toast = null;
       this.toastTimer = null;
       this.render();
-    }, 5000);
+    }, 2000);
     this.render();
   }
 


### PR DESCRIPTION
We bind ctrl + c to copy since that is the key bind in chrome, but users might get stuck if they think ctrl c is for quitting. Now if no text i selected ctrl + c shows a toast with the actual key bind for quitting on linux 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->