### PR TITLE
fix: detect pixel-mode mouse coords when DECRQM confirmation never arrives

### DIFF
--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -763,7 +763,13 @@ impl Terminal {
         }
     }
 
-    fn mouse_position_px(&self, x: u32, y: u32) -> (u32, u32) {
+    fn mouse_position_px(&mut self, x: u32, y: u32) -> (u32, u32) {
+        if !self.mouse_pixels
+            && let Ok(ws) = self.size()
+            && (x > ws.cols || y > ws.rows)
+        {
+            self.mouse_pixels = true;
+        }
         if self.mouse_pixels {
             (x.saturating_sub(1), y.saturating_sub(1))
         } else {


### PR DESCRIPTION
## Summary
- Konsole never replies to the DECRQM query (`CSI ? 1016 $ p`) used to confirm SGR-pixel mouse mode is active, so `mouse_pixels` stayed false and pixel coordinates got misread as cell coordinates, breaking clicks entirely on Konsole.
- A cell coordinate can never exceed the terminal's own column/row count, so an incoming mouse report larger than that can only be a pixel coordinate that slipped through undetected. `mouse_position_px` now latches `mouse_pixels = true` the first time it sees an out-of-range report, instead of relying solely on the DECRQM confirmation.

Fixes #32

## Test plan
- [x] `cargo check -p pixel-core` passes
- [x] Verify clicking works correctly in Konsole on Fedora
- [x] Verify no regression in terminals that do answer DECRQM correctly (xterm, foot, wezterm, kitty)

## Video

[Screencast_20260811_122211.webm](https://github.com/user-attachments/assets/db445ece-bb70-4515-a1df-cc716e55c109)
