### PR TITLE
fix: detect available AppArmor ABI in apparmor.sh

### DIFF
--- a/scripts/apparmor.sh
+++ b/scripts/apparmor.sh
@@ -23,7 +23,19 @@ BINARY="$(readlink -f "$BINARY")"
 NAME="terminal-browser-$(printf '%s' "$BINARY" | sha256sum | cut -c1-12)"
 PROFILE="/etc/apparmor.d/$NAME"
 
-WANTED="abi <abi/5.0>,
+# Ubuntu 24.04 ships AppArmor 4.x (abi/4.0 only). Newer releases may have abi/5.0.
+if [ -f /etc/apparmor.d/abi/5.0 ]; then
+  ABI=5.0
+elif [ -f /etc/apparmor.d/abi/4.0 ]; then
+  ABI=4.0
+elif [ -f /etc/apparmor.d/abi/3.0 ]; then
+  ABI=3.0
+else
+  echo "no AppArmor abi under /etc/apparmor.d/abi/ — cannot install profile" >&2
+  exit 1
+fi
+
+WANTED="abi <abi/${ABI}>,
 
 include <tunables/global>
 


### PR DESCRIPTION
## Motivation

On Ubuntu 24.04 LTS, AppArmor 4.x only ships `abi/4.0` under `/etc/apparmor.d/abi/`. `scripts/apparmor.sh` currently hardcodes `abi <abi/5.0>,`, so `apparmor_parser` fails with:

```
Could not open 'abi/5.0': No such file or directory
```

The script then deletes the profile. Chromium never gets the `userns` grant required when `apparmor_restrict_unprivileged_userns=1`, and terminal-browser cannot start.

Fixes #34.

## Change

Select the highest present ABI file (`5.0` → `4.0` → `3.0`) when writing the profile. If none exist, exit with a clear error instead of writing a profile the parser will reject.

No CLI/TS changes — only the shell helper invoked by `apparmorSetup()`.

## Test plan

- [x] Reproduced on Ubuntu 24.04.4 / AppArmor 4.0.1 (`abi/4.0` only; no `abi/5.0`)
- [x] `bash -n scripts/apparmor.sh`
- [ ] With the change, profile installs and `apparmor_parser -r` succeeds (needs sudo once)
- [ ] `terminal-browser` launches without the AppArmor userns error