### PR TITLE
Pass env through to herdr initialization code to write frames to the right pane

### DIFF
--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -219,6 +219,7 @@ class Session {
     this.root = createRoot({
       tty: this.ctx.tty,
       wrapper: this.terminal?.wrapper,
+      sessionEnv: this.ctx.env,
       keyEventTypes: true,
       onKey: (event) => this.handleKey(event),
       onPaste: (text) => {

--- a/engine/crates/pixel-core/src/engine/mod.rs
+++ b/engine/crates/pixel-core/src/engine/mod.rs
@@ -67,6 +67,7 @@ pub struct EngineConfig {
     pub watch_resize: bool,
     pub tty: Option<String>,
     pub wrapper: Wrapper,
+    pub session_env: crate::terminal::SessionEnv,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -334,8 +335,10 @@ impl Engine {
     pub fn new(config: EngineConfig) -> io::Result<Self> {
         assert!(!config.fonts.is_empty());
         let mut term = match &config.tty {
-            Some(path) => Terminal::open(path, config.wrapper)?,
-            None => Terminal::new(config.wrapper)?,
+            Some(path) => {
+                Terminal::open_with_env(path, config.wrapper, config.session_env.clone())?
+            }
+            None => Terminal::new_with_env(config.wrapper, config.session_env.clone())?,
         };
         if config.watch_resize {
             term.watch_resize()?;

--- a/engine/crates/pixel-core/src/engine/mod.rs
+++ b/engine/crates/pixel-core/src/engine/mod.rs
@@ -335,10 +335,8 @@ impl Engine {
     pub fn new(config: EngineConfig) -> io::Result<Self> {
         assert!(!config.fonts.is_empty());
         let mut term = match &config.tty {
-            Some(path) => {
-                Terminal::open_with_env(path, config.wrapper, config.session_env.clone())?
-            }
-            None => Terminal::new_with_env(config.wrapper, config.session_env.clone())?,
+            Some(path) => Terminal::open(path, config.wrapper, config.session_env.clone())?,
+            None => Terminal::new(config.wrapper, config.session_env.clone())?,
         };
         if config.watch_resize {
             term.watch_resize()?;

--- a/engine/crates/pixel-core/src/herdr.rs
+++ b/engine/crates/pixel-core/src/herdr.rs
@@ -6,9 +6,24 @@ use std::time::Duration;
 use crate::canvas::Canvas;
 use crate::terminal::FrameFile;
 
-const ACK_TIMEOUT: Duration = Duration::from_secs(5);
+const ACK_TIMEOUT: Duration = Duration::from_secs(12);
 const OPEN_TIMEOUT: Duration = Duration::from_secs(2);
 const SLOTS: u64 = 3;
+
+#[derive(Clone, Debug)]
+pub(crate) struct HerdrTarget {
+    pub(crate) pane: String,
+    pub(crate) socket: String,
+}
+
+impl HerdrTarget {
+    pub(crate) fn from_env(env: &crate::terminal::SessionEnv) -> Option<Self> {
+        Some(Self {
+            pane: env.var("HERDR_PANE_ID")?,
+            socket: env.var("HERDR_SOCKET_PATH")?,
+        })
+    }
+}
 
 pub(crate) struct Herdr {
     frames: BufReader<UnixStream>,
@@ -16,16 +31,16 @@ pub(crate) struct Herdr {
     cell: (u32, u32),
     files: Vec<FrameFile>,
     retired: Vec<FrameFile>,
+    instance: u64,
     generation: u64,
     seq: u64,
 }
 
 impl Herdr {
-    pub(crate) fn open() -> Option<Self> {
-        Self::connect(
-            &std::env::var("HERDR_PANE_ID").ok()?,
-            &std::env::var("HERDR_SOCKET_PATH").ok()?,
-        )
+    pub(crate) fn open(target: &HerdrTarget, instance: u64) -> Option<Self> {
+        let mut herdr = Self::connect(&target.pane, &target.socket)?;
+        herdr.instance = instance;
+        Some(herdr)
     }
 
     fn connect(pane: &str, socket: &str) -> Option<Self> {
@@ -74,6 +89,7 @@ impl Herdr {
             cell,
             files: Vec::new(),
             retired: Vec::new(),
+            instance: 0,
             generation: 0,
             seq: 0,
         })
@@ -81,6 +97,27 @@ impl Herdr {
 
     pub(crate) fn cell(&self) -> (u32, u32) {
         self.cell
+    }
+
+    pub(crate) fn mouse_position_px(
+        &self,
+        kind: crate::terminal::MouseKind,
+        x: u32,
+        y: u32,
+        focused: bool,
+        pixel_mouse: bool,
+        grid: impl FnOnce() -> Option<crate::terminal::WindowSize>,
+    ) -> (u32, u32) {
+        let (cell_w, cell_h) = self.cell;
+        let cell_center =
+            |x: u32, y: u32| ((x - 1) * cell_w + cell_w / 2, (y - 1) * cell_h + cell_h / 2);
+        if !pixel_mouse {
+            return cell_center(x, y);
+        }
+        if !focused && is_wheel(kind) && grid().is_some_and(|ws| within_grid(&ws, x, y)) {
+            return cell_center(x, y);
+        }
+        (x.saturating_sub(1), y.saturating_sub(1))
     }
 
     pub(crate) fn present(&mut self, canvas: &Canvas) -> io::Result<usize> {
@@ -112,8 +149,9 @@ impl Herdr {
             for slot in 0..SLOTS {
                 self.files.push(FrameFile::create(
                     self.directory.join(format!(
-                        "px-{}-{}-{slot}",
+                        "px-{}-{}-{}-{slot}",
                         std::process::id(),
+                        self.instance,
                         self.generation
                     )),
                     pixels.len(),
@@ -124,6 +162,21 @@ impl Herdr {
         file.write(pixels);
         Ok(file.path().to_string_lossy().into_owned())
     }
+}
+
+fn is_wheel(kind: crate::terminal::MouseKind) -> bool {
+    use crate::terminal::MouseKind;
+    matches!(
+        kind,
+        MouseKind::ScrollUp
+            | MouseKind::ScrollDown
+            | MouseKind::ScrollLeft
+            | MouseKind::ScrollRight
+    )
+}
+
+fn within_grid(ws: &crate::terminal::WindowSize, x: u32, y: u32) -> bool {
+    x >= 1 && y >= 1 && x <= ws.cols && y <= ws.rows
 }
 
 fn request(socket: &str, line: &str) -> io::Result<String> {
@@ -247,7 +300,7 @@ mod tests {
 
     /// Answers like herdr does: one info reply per connection, then a stream
     /// that acks every frame. Collects the frame headers it was sent.
-    fn fake_herdr(
+    pub(super) fn fake_herdr(
         directory: &std::path::Path,
         transport: &str,
     ) -> (PathBuf, std::sync::mpsc::Receiver<String>) {
@@ -282,7 +335,7 @@ mod tests {
         (socket, rx)
     }
 
-    fn scratch(name: &str) -> PathBuf {
+    pub(super) fn scratch(name: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("pixel-herdr-{}-{name}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
@@ -364,5 +417,88 @@ mod tests {
     fn quoting_survives_a_path_with_characters_json_cares_about() {
         assert_eq!(quote(r#"/tmp/a"b\c"#), r#""/tmp/a\"b\\c""#);
         assert_eq!(field_str(&format!(r#"{{"p":{}}}"#, quote(r#"/a"b\c"#)), "p").as_deref(), Some(r#"/a"b\c"#));
+    }
+}
+
+#[cfg(test)]
+mod shared_process_tests {
+    use super::*;
+    use crate::canvas::Canvas;
+
+    #[test]
+    fn engines_sharing_a_process_use_distinct_frame_files() {
+        let dir = tests::scratch("shared-process");
+        let dir_b = tests::scratch("shared-process-b");
+        let (socket_a, _frames_a) = tests::fake_herdr(&dir, "direct-kitty");
+        let (socket_b, _frames_b) = tests::fake_herdr(&dir_b, "direct-kitty");
+        let mut a = Herdr::connect("w1:p1", &socket_a.to_string_lossy()).unwrap();
+        let mut b = Herdr::connect("w1:p2", &socket_b.to_string_lossy()).unwrap();
+        // Both engines share one process and one frame directory, as when
+        // the daemon hosts two herdr sessions.
+        b.directory = dir.clone();
+        b.instance = 1;
+
+        let canvas = Canvas::new(40, 40);
+        a.present(&canvas).unwrap();
+        let path_a = a.files[0].path().to_owned();
+        b.present(&canvas).unwrap();
+        let path_b = b.files[0].path().to_owned();
+
+        assert_ne!(path_a, path_b, "same-process engines must not share frame files");
+        // Writing B's frames must leave A's mapped file fully intact; a
+        // truncated file here means A's next frame copy dies of SIGBUS.
+        assert_eq!(std::fs::metadata(&path_a).unwrap().len(), 40 * 40 * 4);
+        assert_eq!(std::fs::metadata(&path_b).unwrap().len(), 40 * 40 * 4);
+        a.present(&canvas).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod degraded_wheel_tests {
+    use super::*;
+    use crate::terminal::{MouseKind, WindowSize};
+
+    fn grid() -> Option<WindowSize> {
+        Some(WindowSize {
+            cols: 120,
+            rows: 40,
+            width_px: 1200,
+            height_px: 800,
+        })
+    }
+
+    #[test]
+    fn unfocused_in_grid_wheel_rescales_to_cell_centers() {
+        let dir = tests::scratch("degraded-wheel");
+        let (socket, _frames) = tests::fake_herdr(&dir, "direct-kitty");
+        // fake_herdr advertises a 10x20 cell size.
+        let herdr = Herdr::connect("w1:p1", &socket.to_string_lossy()).unwrap();
+
+        // The bug case: an unfocused wheel arrives as cells (8, 9) and is
+        // rescaled to the cell center.
+        assert_eq!(
+            herdr.mouse_position_px(MouseKind::ScrollUp, 8, 9, false, true, grid),
+            (75, 170)
+        );
+        // Focused wheels are honest pixels; pass them through 0-based.
+        assert_eq!(
+            herdr.mouse_position_px(MouseKind::ScrollUp, 8, 9, true, true, grid),
+            (7, 8)
+        );
+        // Coordinates beyond the cell grid can only be pixels.
+        assert_eq!(
+            herdr.mouse_position_px(MouseKind::ScrollDown, 640, 9, false, true, grid),
+            (639, 8)
+        );
+        // Without pixel mouse mode every report is cells.
+        assert_eq!(
+            herdr.mouse_position_px(MouseKind::ScrollUp, 8, 9, false, false, grid),
+            (75, 170)
+        );
+        // Only wheels: clicks focus the pane first, so they stay untouched.
+        assert_eq!(
+            herdr.mouse_position_px(MouseKind::Down, 8, 9, false, true, grid),
+            (7, 8)
+        );
     }
 }

--- a/engine/crates/pixel-core/src/lib.rs
+++ b/engine/crates/pixel-core/src/lib.rs
@@ -35,6 +35,7 @@ pub use kitty::kitty_transmit;
 pub use logging::{LogEntry, LogLevel};
 pub use menu::{CONTEXT_MENU_KEY, MenuEntry, MenuItem, MenuStyle, context_menu};
 pub use native::{NativeEvent, NativeScroll};
+pub use terminal::SessionEnv;
 pub use paint::paint;
 pub use profiler::{CounterRecord, ProfileData, Profiler, SpanRecord};
 pub use shape::{LineCap, LineJoin, PathCmd, ShapeProps, ShapeStroke, build_path, parse_path_data, skia_stroke};

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -334,11 +334,7 @@ impl SessionEnv {
 }
 
 impl Terminal {
-    pub fn new(wrapper: Wrapper) -> io::Result<Self> {
-        Self::new_with_env(wrapper, SessionEnv::of_process())
-    }
-
-    pub fn new_with_env(wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
+    pub fn new(wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
         Self::with_handle(
             TtyHandle::Stdio {
                 stdin: io::stdin(),
@@ -349,11 +345,7 @@ impl Terminal {
         )
     }
 
-    pub fn open(tty_path: &str, wrapper: Wrapper) -> io::Result<Self> {
-        Self::open_with_env(tty_path, wrapper, SessionEnv::of_process())
-    }
-
-    pub fn open_with_env(tty_path: &str, wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
+    pub fn open(tty_path: &str, wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
         let file = std::fs::File::options().read(true).write(true).open(tty_path)?;
         Self::with_handle(TtyHandle::File(file), wrapper, env)
     }
@@ -2481,8 +2473,8 @@ mod tty_tests {
         let (master_b, _slave_b, path_b) = open_pty();
         let _drain_a = drain(&master_a);
         let _drain_b = drain(&master_b);
-        let mut a = Terminal::open(&path_a, Wrapper::None).unwrap();
-        let mut b = Terminal::open(&path_b, Wrapper::None).unwrap();
+        let mut a = Terminal::open(&path_a, Wrapper::None, SessionEnv::of_process()).unwrap();
+        let mut b = Terminal::open(&path_b, Wrapper::None, SessionEnv::of_process()).unwrap();
 
         assert_ne!(a.terminal_id, b.terminal_id);
         assert_ne!(a.shm_name(0), b.shm_name(0));
@@ -2516,7 +2508,7 @@ mod tty_tests {
         use std::io::Write as _;
         let (mut master, _slave, path) = open_pty();
         let _drain = drain(&master);
-        let mut term = Terminal::open(&path, Wrapper::Tmux).unwrap();
+        let mut term = Terminal::open(&path, Wrapper::Tmux, SessionEnv::of_process()).unwrap();
 
         master.write_all(b"\x1b").unwrap();
         let got = term.poll_event(Some(Duration::from_millis(500))).unwrap();
@@ -2538,7 +2530,7 @@ mod tty_tests {
         use std::io::Write as _;
         let (mut master, _slave, path) = open_pty();
         let _drain = drain(&master);
-        let mut term = Terminal::open(&path, Wrapper::None).unwrap();
+        let mut term = Terminal::open(&path, Wrapper::None, SessionEnv::of_process()).unwrap();
 
         master.write_all(b"\x1b").unwrap();
         let got = term.poll_event(Some(Duration::from_millis(200))).unwrap();
@@ -2549,7 +2541,7 @@ mod tty_tests {
     fn a_wake_ends_a_blocking_poll() {
         let (master, _slave, path) = open_pty();
         let _drain = drain(&master);
-        let mut term = Terminal::open(&path, Wrapper::None).unwrap();
+        let mut term = Terminal::open(&path, Wrapper::None, SessionEnv::of_process()).unwrap();
         let waker = term.waker().unwrap();
 
         std::thread::spawn(move || {

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -229,12 +229,15 @@ pub struct Terminal {
     saved: Termios,
     last_frame_size: Option<(u32, u32)>,
     mouse_pixels: bool,
+    focused: bool,
     cell: Option<(u32, u32)>,
     cell_query_unsupported: bool,
     pending: Vec<u8>,
     lone_escape_since: Option<Instant>,
     transport: FrameTransport,
     herdr: Option<crate::herdr::Herdr>,
+    herdr_target: Option<crate::herdr::HerdrTarget>,
+    herdr_retry: Option<(Instant, Duration)>,
     frame_files: Vec<FrameFile>,
     frame_seq: u64,
     wrapper: Wrapper,
@@ -308,23 +311,54 @@ impl Waker {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct SessionEnv {
+    session: Option<std::collections::HashMap<String, String>>,
+}
+
+impl SessionEnv {
+    pub fn of_session(env: std::collections::HashMap<String, String>) -> Self {
+        Self { session: Some(env) }
+    }
+
+    pub fn of_process() -> Self {
+        Self { session: None }
+    }
+
+    pub(crate) fn var(&self, key: &str) -> Option<String> {
+        match &self.session {
+            Some(env) => env.get(key).cloned(),
+            None => std::env::var(key).ok(),
+        }
+    }
+}
+
 impl Terminal {
     pub fn new(wrapper: Wrapper) -> io::Result<Self> {
+        Self::new_with_env(wrapper, SessionEnv::of_process())
+    }
+
+    pub fn new_with_env(wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
         Self::with_handle(
             TtyHandle::Stdio {
                 stdin: io::stdin(),
                 stdout: io::stdout(),
             },
             wrapper,
+            env,
         )
     }
 
     pub fn open(tty_path: &str, wrapper: Wrapper) -> io::Result<Self> {
-        let file = std::fs::File::options().read(true).write(true).open(tty_path)?;
-        Self::with_handle(TtyHandle::File(file), wrapper)
+        Self::open_with_env(tty_path, wrapper, SessionEnv::of_process())
     }
 
-    fn with_handle(mut io: TtyHandle, wrapper: Wrapper) -> io::Result<Self> {
+    pub fn open_with_env(tty_path: &str, wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
+        let file = std::fs::File::options().read(true).write(true).open(tty_path)?;
+        Self::with_handle(TtyHandle::File(file), wrapper, env)
+    }
+
+    fn with_handle(mut io: TtyHandle, wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
         let saved = retry_intr(|| termios::tcgetattr(&io.read_fd()))?;
         let mut raw = saved.clone();
         raw.make_raw();
@@ -341,12 +375,15 @@ impl Terminal {
             saved,
             last_frame_size: None,
             mouse_pixels: false,
+            focused: true,
             cell: None,
             cell_query_unsupported: false,
             pending: Vec::new(),
             lone_escape_since: None,
             transport: FrameTransport::Inline,
             herdr: None,
+            herdr_target: crate::herdr::HerdrTarget::from_env(&env),
+            herdr_retry: None,
             frame_files: Vec::new(),
             frame_seq: 0,
             wrapper,
@@ -369,9 +406,9 @@ impl Terminal {
         }
         terminal.mouse_pixels = !wrapper.relayed() && terminal.probe_mouse_pixels()?;
         terminal.clipboard_data = !wrapper.relayed() && terminal.probe_clipboard_data()?;
-        terminal.herdr = crate::herdr::Herdr::open();
-        if let Some(cell) = terminal.herdr.as_ref().map(crate::herdr::Herdr::cell) {
-            terminal.cell = Some(cell);
+        terminal.connect_herdr();
+        if terminal.herdr.is_none() && terminal.herdr_target.is_some() {
+            terminal.herdr_retry = Some((Instant::now() + HERDR_RETRY_MIN, HERDR_RETRY_MIN));
         }
         terminal.transport = terminal.probe_transport()?;
         terminal.color_scheme_updates = terminal.probe_color_scheme()?;
@@ -517,13 +554,40 @@ impl Terminal {
         Ok(name)
     }
 
+    fn connect_herdr(&mut self) {
+        self.herdr = self
+            .herdr_target
+            .as_ref()
+            .and_then(|target| crate::herdr::Herdr::open(target, self.terminal_id));
+        if let Some(cell) = self.herdr.as_ref().map(crate::herdr::Herdr::cell) {
+            self.cell = Some(cell);
+        }
+    }
+
     pub fn draw(&mut self, canvas: &Canvas) -> io::Result<usize> {
+        if self.herdr.is_none()
+            && let Some((at, backoff)) = self.herdr_retry
+            && Instant::now() >= at
+        {
+            self.connect_herdr();
+            match self.herdr {
+                Some(_) => self.herdr_retry = None,
+                None => {
+                    let backoff = (backoff * 2).min(HERDR_RETRY_MAX);
+                    self.herdr_retry = Some((Instant::now() + backoff, backoff));
+                }
+            }
+        }
         if let Some(herdr) = self.herdr.as_mut() {
             match herdr.present(canvas) {
                 Ok(written) => return Ok(written),
                 Err(err) => {
-                    crate::logging::warn("herdr", format!("{err}, drawing it ourselves instead"));
+                    crate::logging::warn(
+                        "herdr",
+                        format!("{err}, drawing it ourselves until herdr is back"),
+                    );
                     self.herdr = None;
+                    self.herdr_retry = Some((Instant::now() + HERDR_RETRY_MIN, HERDR_RETRY_MIN));
                     self.last_frame_size = None;
                     self.placeholders = None;
                 }
@@ -629,10 +693,23 @@ impl Terminal {
                 return Ok(Some(match raw {
                     RawEvent::Key(key) => Event::Key(key),
                     RawEvent::Paste(text) => Event::Paste(text),
-                    RawEvent::Focus(focused) => Event::Focus(focused),
+                    RawEvent::Focus(focused) => {
+                        self.focused = focused;
+                        Event::Focus(focused)
+                    }
                     RawEvent::WindowSize(ws) => Event::WindowSize(ws),
                     RawEvent::Mouse(kind, button, mods, x, y) => {
-                        let (x, y) = self.mouse_position_px(x, y);
+                        let (x, y) = match &self.herdr {
+                            Some(herdr) => herdr.mouse_position_px(
+                                kind,
+                                x,
+                                y,
+                                self.focused,
+                                self.mouse_pixels,
+                                || self.size().ok(),
+                            ),
+                            None => self.mouse_position_px(x, y),
+                        };
                         Event::Mouse(Mouse {
                             kind,
                             button,
@@ -1042,6 +1119,9 @@ const FRAME_PROBE_TIMEOUT_MS: u64 = 300;
 
 const FRAME_SLOTS: u64 = 8;
 
+const HERDR_RETRY_MIN: Duration = Duration::from_secs(1);
+const HERDR_RETRY_MAX: Duration = Duration::from_secs(10);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FrameTransport {
     File,
@@ -1084,12 +1164,12 @@ pub(crate) struct FrameFile {
 impl FrameFile {
     pub(crate) fn create(path: std::path::PathBuf, len: usize) -> io::Result<Self> {
         use std::os::unix::fs::OpenOptionsExt;
+        let _ = std::fs::remove_file(&path);
         let file = std::fs::File::options()
             .mode(0o600)
             .read(true)
             .write(true)
-            .create(true)
-            .truncate(true)
+            .create_new(true)
             .open(&path)?;
         rustix::fs::ftruncate(&file, len as u64)?;
         let map = unsafe {
@@ -1132,7 +1212,7 @@ impl Drop for FrameFile {
 }
 
 #[allow(unsafe_code)]
-fn write_shm(name: &str, data: &[u8]) -> io::Result<()> {
+pub(crate) fn write_shm(name: &str, data: &[u8]) -> io::Result<()> {
     let fd = rustix::shm::open(
         name,
         rustix::shm::OFlags::CREATE | rustix::shm::OFlags::EXCL | rustix::shm::OFlags::RDWR,

--- a/engine/crates/pixel-node/src/lib.rs
+++ b/engine/crates/pixel-node/src/lib.rs
@@ -295,17 +295,26 @@ pub struct PixelEngine {
 #[napi]
 impl PixelEngine {
     #[napi(constructor)]
-    pub fn new(tty: Option<String>, wrapper: Option<String>) -> Result<Self> {
+    pub fn new(
+        tty: Option<String>,
+        wrapper: Option<String>,
+        session_env: Option<std::collections::HashMap<String, String>>,
+    ) -> Result<Self> {
         let fonts = vec![
             load_font(SYSTEM_UI_FONTS, UI_FONT_BYTES),
             load_font(SYSTEM_MONO_FONTS, MONO_FONT_BYTES),
         ];
+        let session_env = match session_env {
+            Some(env) => pixel_core::SessionEnv::of_session(env),
+            None => pixel_core::SessionEnv::of_process(),
+        };
         let mut engine = Engine::new(EngineConfig {
             fonts,
             cell_metrics_font: 1,
             watch_resize: false,
             tty,
             wrapper: pixel_core::wrapper::Wrapper::named(wrapper.as_deref()),
+            session_env,
         })
         .map_err(err)?;
         let waker = engine.term.waker().map_err(err)?;

--- a/engine/packages/pixel-react/src/index.ts
+++ b/engine/packages/pixel-react/src/index.ts
@@ -168,6 +168,7 @@ export interface RootOptions {
   devtools?: boolean;
   tty?: string;
   wrapper?: "tmux";
+  sessionEnv?: NodeJS.ProcessEnv;
 }
 
 export interface PixelRoot {
@@ -259,7 +260,7 @@ function applyColors(colors: TerminalColors): void {
 
 export function createRoot(options: RootOptions = {}): PixelRoot {
   const bridge = options.tty
-    ? new Bridge(options.tty, options.wrapper)
+    ? new Bridge(options.tty, options.wrapper, options.sessionEnv)
     : getBridge(options.wrapper);
   const devtoolsEnabled = options.devtools !== false && bridge === getBridge();
   if (devtoolsEnabled) {

--- a/engine/packages/pixel-react/src/native.ts
+++ b/engine/packages/pixel-react/src/native.ts
@@ -125,7 +125,11 @@ export interface DiffRow {
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const binding = require("../native/pixel.node") as {
-  PixelEngine: new (tty?: string, wrapper?: string) => NativeEngine;
+  PixelEngine: new (
+    tty?: string,
+    wrapper?: string,
+    sessionEnv?: Record<string, string>,
+  ) => NativeEngine;
   highlight(source: string, language: string): HighlightSpan[];
   highlightCaptures(): string[];
   diff(oldSource: string, newSource: string, contextLines?: number): DiffRow[];
@@ -143,8 +147,19 @@ const binding = require("../native/pixel.node") as {
   ): Promise<Buffer>;
 };
 
-export function createNativeEngine(tty?: string, wrapper?: string): NativeEngine {
-  const pixelEngine =  new binding.PixelEngine(tty, wrapper);
+export function createNativeEngine(
+  tty?: string,
+  wrapper?: string,
+  sessionEnv?: NodeJS.ProcessEnv,
+): NativeEngine {
+  const env = sessionEnv
+    ? Object.fromEntries(
+        Object.entries(sessionEnv).filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        ),
+      )
+    : undefined;
+  const pixelEngine = new binding.PixelEngine(tty, wrapper, env);
 
   return pixelEngine
 }

--- a/engine/packages/pixel-react/src/reconciler-config.ts
+++ b/engine/packages/pixel-react/src/reconciler-config.ts
@@ -266,8 +266,8 @@ export class Bridge {
   private nextId = 1;
   private seq = 0;
 
-  constructor(tty?: string, wrapper?: string) {
-    this.engine = createNativeEngine(tty, wrapper);
+  constructor(tty?: string, wrapper?: string, sessionEnv?: NodeJS.ProcessEnv) {
+    this.engine = createNativeEngine(tty, wrapper, sessionEnv);
     if (!defaultBridge) defaultBridge = this;
   }
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "terminal-graphics-engine",
   "private": true,
   "scripts": {
+    "build": "pnpm -r build",
     "browser": "pnpm --filter terminal-browser start",
     "build:dist": "scripts/release.sh \"local-$(git rev-parse --short HEAD)\"",
     "install:dist": "scripts/install-local.sh",


### PR DESCRIPTION
Because we have one long running daemon process that runs all graphics engine threads, we made a mistake where we read the environment variables of the daemon process to determine what herdr pane we were in. This means if you ran `terminal-browser` in one pane, then made a new tab, and ran `terminal-browser` again in a new pane, it would try to write to the pane in the previous browser tab.

We fix this by passing through the env variables from the cli process (not daemon) down to the engine thread so when it draws to the terminal it targets the right herdr pane

We also include a slight improvement when running inside herdr to handle scrolling when the pane is not focused. `terminal-browser` enables a mode in the terminal to receive pixel coordinates of the mouse position. When a herdr pane unfocuses it starts emitting cell coordinates for mouse positin, and our browser has no way of knowing of this change. So when scrolling the browser when unfocused, the computed mouse position is wrong. We special case herdr to solve this by checking if we are in herdr, and the pane is unfocused, if so we ignore the terminal state that pixel mouse reporting is on, and we map the coordinates passed to us by the terminal into pixel coordinates by multiplying by cell sizes. This will likely blow up in our faces if herdr fixes this bug because then we will be incorrectly transforming pixel coordinates -> pixel coordinates * cell size.  But this would only be the case for a small region in the top left corner of the browser 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->