### PR TITLE
Handle window close

### DIFF
--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -72,6 +72,7 @@ export class BrowserController {
   onDevtoolsChange: (() => void) | null = null;
   onDevtoolsAction: ((action: DevtoolsAction) => void) | null = null;
   onContextMenu: ((params: Electron.ContextMenuParams) => void) | null = null;
+  onClosed: (() => void) | null = null;
 
   constructor(
     surface: Surface,
@@ -139,6 +140,7 @@ export class BrowserController {
       },
     });
     this.window.webContents.setFrameRate(frameRate());
+    this.window.on("closed", this.onWindowClosed);
     screen.on("display-added", this.onDisplayChange);
     screen.on("display-removed", this.onDisplayChange);
     screen.on("display-metrics-changed", this.onDisplayChange);
@@ -378,6 +380,7 @@ export class BrowserController {
   }
 
   focusContent(): Promise<void> | undefined {
+    if (this.stopped) return;
     this.blurDevtools();
     if (this.contentFocused) return;
     this.window.focus();
@@ -451,14 +454,17 @@ export class BrowserController {
   }
 
   pointer(event: PointerEvent) {
+    if (this.stopped) return;
     this.input.pointer(event);
   }
 
   wheel(event: WheelEvent) {
+    if (this.stopped) return;
     this.input.wheel(event);
   }
 
   key(event: EngineKeyEvent) {
+    if (this.stopped) return;
     this.input.key(event);
   }
 
@@ -490,14 +496,25 @@ export class BrowserController {
   stop() {
     if (this.stopped) return;
     this.stopped = true;
+    this.teardown();
+    this.window.destroy();
+  }
+
+  private teardown() {
     for (const popup of [...this.popups]) popup.close();
     this.devtools?.close();
     screen.off("display-added", this.onDisplayChange);
     screen.off("display-removed", this.onDisplayChange);
     screen.off("display-metrics-changed", this.onDisplayChange);
     this.surface.close();
-    this.window.destroy();
   }
+
+  private readonly onWindowClosed = () => {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.teardown();
+    this.onClosed?.();
+  };
 
   setVisible(visible: boolean) {
     if (this.visible === visible) return;

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -276,6 +276,7 @@ class Session {
         },
         onPageMenu: (params) => this.openPageMenu(params),
         onTabOpened: (opener, url) => this.records.get(opener)?.linkOpened(url),
+        onTabClosed: (id) => this.closeOrShutdown(id),
         tabSwitchAllowed: () => !this.activeRecord()?.reviewing,
         onTabsChanged: () => {
           this.registry?.update();
@@ -456,6 +457,11 @@ class Session {
     else if (process.platform === "linux") this.showToast("ctrl+q to quit", "alert");
   }
 
+  private closeOrShutdown(id: number) {
+    if (this.tabs.count <= 1) this.shutdown();
+    else this.tabs.close(id);
+  }
+
   shutdown(code = 0) {
     if (this.shuttingDown) return;
     this.shuttingDown = true;
@@ -631,7 +637,7 @@ class Session {
     paletteRun: (index) => this.runPalette(index),
     paletteClose: () => this.closePalette(),
     tabSwitch: (id) => this.tabs.activate(id),
-    tabClose: (id) => (this.tabs.count <= 1 ? this.shutdown() : this.tabs.close(id)),
+    tabClose: (id) => this.closeOrShutdown(id),
     tabNew: () => this.openNewTabModal(),
     newTabQuery: (text) => this.newTabQuery(text),
     newTabSubmit: (text) => {

--- a/browser/src/session/tabs.ts
+++ b/browser/src/session/tabs.ts
@@ -36,6 +36,7 @@ export interface TabHost {
   onPageMenu(params: Electron.ContextMenuParams): void;
   onTabsChanged(): void;
   onTabOpened(opener: BrowserController, url: string): void;
+  onTabClosed(id: number): void;
   tabSwitchAllowed(): boolean;
   requestRender(): void;
 }
@@ -93,6 +94,7 @@ export class TabManager {
       this.host.onTabOpened(tab.controller, openUrl);
     };
     tab.controller.onPopupChange = () => this.host.requestRender();
+    tab.controller.onClosed = () => this.host.onTabClosed(tab.id);
     tab.controller.onDevtoolsChange = () => {
       if (tab.id === this.activeId) this.host.onDevtoolsChanged();
       else this.host.requestRender();


### PR DESCRIPTION
If a page programatically tries to close itself via `window.close` terminal-browser` needs to cleanup the tab, close the browser itself if is the last tab, and not try to access a closed window
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->