### PR TITLE
fix missing window close guards, add quit url so vscode can close itself

### DIFF
--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -211,6 +211,7 @@ export class BrowserController {
   }
 
   resize(layout: BrowserSurfaceLayout, options?: { keepFrame?: boolean }) {
+    if (this.stopped) return;
     if (
       this.layout.x === layout.x &&
       this.layout.y === layout.y &&
@@ -517,6 +518,7 @@ export class BrowserController {
   };
 
   setVisible(visible: boolean) {
+    if (this.stopped) return;
     if (this.visible === visible) return;
     this.visible = visible;
     this.popup?.setVisible(visible);
@@ -534,6 +536,7 @@ export class BrowserController {
   }
 
   invalidate(): void {
+    if (this.stopped) return;
     this.wholeSurfaceNext = true;
     this.window.webContents.invalidate();
   }
@@ -563,6 +566,12 @@ export class BrowserController {
     { url, disposition, features }: Electron.HandlerDetails,
     opener: Electron.WebContents,
   ): Electron.WindowOpenHandlerResponse {
+    if (url.startsWith("terminal-browser://quit")) {
+      setImmediate(() => {
+        if (!this.stopped) this.window.close();
+      });
+      return { action: "deny" };
+    }
     const wantsTab = disposition === "foreground-tab" || disposition === "background-tab";
     if (wantsTab && !this.tabsAsPopups && this.onOpenTab) {
       this.onOpenTab(url, disposition === "foreground-tab");


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->