### PR TITLE
fix: daemon memory leaks and orphaned processes

### DIFF
--- a/browser/src/daemon.ts
+++ b/browser/src/daemon.ts
@@ -62,6 +62,14 @@ export async function runDaemon(cdpPort: number | null): Promise<void> {
   };
   process.on("SIGINT", () => stopEverything(130));
   process.on("SIGTERM", () => stopEverything(143));
+  process.on("uncaughtException", (error) => {
+    process.stderr.write(`terminal-browser daemon uncaught exception: ${error}\n`);
+    stopEverything(1);
+  });
+  process.on("unhandledRejection", (reason) => {
+    process.stderr.write(`terminal-browser daemon unhandled rejection: ${reason}\n`);
+    stopEverything(1);
+  });
 
   const server = net.createServer((connection) => {
     let key: string | null = null;
@@ -72,9 +80,14 @@ export async function runDaemon(cdpPort: number | null): Promise<void> {
       } catch {}
     };
 
+    const MAX_BUFFER = 1024 * 1024;
     let buffer = "";
     connection.on("data", (chunk) => {
       buffer += chunk.toString("utf8");
+      if (buffer.length > MAX_BUFFER) {
+        connection.end();
+        return;
+      }
       let newline = buffer.indexOf("\n");
       while (newline !== -1) {
         const line = buffer.slice(0, newline);
@@ -131,7 +144,7 @@ export async function runDaemon(cdpPort: number | null): Promise<void> {
         } else if (message.cmd === "shutdown") {
           reply({ ok: true, sessions: sessions.size });
           connection.end();
-          setTimeout(() => app.exit(0), 50);
+          stopEverything(0);
         }
       }
     });


### PR DESCRIPTION
## Description
Fixes resource leaks and OOM risks in the terminal-browser daemon by capping the IPC buffer and ensuring the daemon always cleans up sessions before exiting. Closes #49.

### Problem
A memory leak investigation showed the daemon could leave browser sessions running or consume unbounded memory:

1. **Unbounded IPC buffer** — `connection.on('data')` appended incoming bytes to a string without a size limit. A client that never sent a newline could make the buffer grow until the system ran out of memory.
2. **Orphaned processes on crash** — `uncaughtException` and `unhandledRejection` were unhandled, so a single thrown error or rejected promise would crash the daemon while leaving child browser sessions alive.
3. **Shutdown bypassed cleanup** — the `shutdown` command scheduled a raw `app.exit(0)` after 50 ms instead of going through `stopEverything()`, so sessions were not reliably closed.

### Changes
- `browser/src/daemon.ts`:
  - Cap the per-connection IPC buffer at 1 MB; close the connection if it overflows.
  - Add `uncaughtException` and `unhandledRejection` handlers that log and call `stopEverything(1)` to close all sessions before exiting.
  - Make the `shutdown` command use `stopEverything(0)` so sessions are closed cleanly.

### Testing
- Stress-tested the IPC buffer limit by sending >1 MB of data without a newline to the daemon socket; the connection is closed and the daemon stays alive.
- Verified shutdown leaves no orphaned `terminal-browser` processes.
- Confirmed uncaught errors now trigger a controlled cleanup and exit.