### PR TITLE
fix: quit URLを明示的権限で制限

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ The following options are the full set of app related options available for `ter
                         page instead.
   --allow-clipboard-read
                         Lets websites read from clipboard.
+  --allow-quit-url      Lets the primary page WebContents close its owning tab when
+                        Electron reports exactly terminal-browser://quit. Disabled
+                        by default. Raw spellings that Electron serializes to that
+                        same string are treated identically. All frames in that
+                        WebContents share the capability. Requests observed as
+                        originating from popup or foreign WebContents are denied,
+                        as are redirects. Under normal browser same-origin semantics,
+                        code executing in the owning page retains its capability.
   --no-toolbar          No toolbar or tab strip
   --no-shortcuts        No browser shortcuts, keys go to the page
   --no-context-menu     No right-click menu

--- a/browser/package.json
+++ b/browser/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -p tsconfig.json",
     "build:engine": "pnpm --filter pixel-react build",
     "start": "pnpm build:engine && pnpm build && pnpm --filter terminal-browser-cli build && exec node ../cli/dist/main.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsc -p tsconfig.json && node --test \"test/*.test.js\"",
+    "test:electron": "tsc -p tsconfig.json && node --test test/electron-quit-url.test.js"
   },
   "dependencies": {
     "pixel-react": "workspace:*",

--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen } from "electron";
+import { BrowserWindow, screen, webContents } from "electron";
 import type {
   EngineKeyEvent,
   PastedImage,
@@ -18,6 +18,8 @@ import { PageInput } from "./input";
 import { offscreenPreferences } from "./offscreen";
 import { BitmapPresenter, presentPaint, shmFrameOf } from "./paint";
 import { PopupWindow } from "./popup";
+import { QuitUrlPolicy, registerQuitUrlNavigationHandlers } from "./quit-url";
+import type { QuitUrlRequest } from "./quit-url";
 import { cssSize, initialBrowserState } from "./types";
 import type { BrowserState, BrowserSurfaceLayout } from "./types";
 import { scaleZoom, stepZoom } from "./zoom";
@@ -38,6 +40,7 @@ export class BrowserController {
   private readonly partition: string | null;
   private readonly tabsAsPopups: boolean;
   private readonly clipboardRead: boolean;
+  private readonly quitUrlPolicy: QuitUrlPolicy;
   private readonly sessionKey: string;
   private readonly cwd: string;
   private background: string;
@@ -86,6 +89,7 @@ export class BrowserController {
     partition: string | null,
     tabsAsPopups: boolean,
     clipboardRead: boolean,
+    allowQuitUrl: boolean,
     sessionKey: string,
     onState: (state: BrowserState) => void,
   ) {
@@ -129,6 +133,7 @@ export class BrowserController {
         additionalArguments: [`--terminal-browser-session=${this.sessionKey}`],
       },
     });
+    this.quitUrlPolicy = new QuitUrlPolicy(allowQuitUrl, this.window.webContents.id);
     if (clipboardRead) allowClipboardRead(this.window.webContents);
     this.input = new PageInput({
       contents: () => this.window.webContents,
@@ -141,9 +146,12 @@ export class BrowserController {
     });
     this.window.webContents.setFrameRate(frameRate());
     this.window.on("closed", this.onWindowClosed);
-    this.window.webContents.on("will-navigate", (event, url) => {
-      if (this.quitLink(url)) event.preventDefault();
-    });
+    registerQuitUrlNavigationHandlers(
+      this.window.webContents,
+      (frame) => webContents.fromFrame(frame),
+      (url, request, targetContentsId, initiatorContentsId) =>
+        this.quitLink(url, targetContentsId, request, initiatorContentsId),
+    );
     screen.on("display-added", this.onDisplayChange);
     screen.on("display-removed", this.onDisplayChange);
     screen.on("display-metrics-changed", this.onDisplayChange);
@@ -567,11 +575,24 @@ export class BrowserController {
     this.onState(this.state);
   }
 
-  private quitLink(url: string): boolean {
-    if (!url.startsWith("terminal-browser://quit")) return false;
-    setImmediate(() => {
-      if (!this.stopped) this.window.close();
-    });
+  private quitLink(
+    url: string,
+    requesterContentsId: number | undefined,
+    request: QuitUrlRequest,
+    initiatorContentsId?: number,
+  ): boolean {
+    const action = this.quitUrlPolicy.request(
+      url,
+      requesterContentsId,
+      request,
+      initiatorContentsId,
+    );
+    if (action === "ignore") return false;
+    if (action === "close") {
+      setImmediate(() => {
+        if (!this.stopped) this.window.close();
+      });
+    }
     return true;
   }
 
@@ -579,7 +600,7 @@ export class BrowserController {
     { url, disposition, features }: Electron.HandlerDetails,
     opener: Electron.WebContents,
   ): Electron.WindowOpenHandlerResponse {
-    if (this.quitLink(url)) return { action: "deny" };
+    if (this.quitLink(url, opener.id, "window-open")) return { action: "deny" };
     const wantsTab = disposition === "foreground-tab" || disposition === "background-tab";
     if (wantsTab && !this.tabsAsPopups && this.onOpenTab) {
       this.onOpenTab(url, disposition === "foreground-tab");
@@ -618,6 +639,12 @@ export class BrowserController {
   }
 
   private adoptPopup(child: Electron.BrowserWindow) {
+    registerQuitUrlNavigationHandlers(
+      child.webContents,
+      (frame) => webContents.fromFrame(frame),
+      (url, request, targetContentsId, initiatorContentsId) =>
+        this.quitLink(url, targetContentsId, request, initiatorContentsId),
+    );
     if (this.clipboardRead) allowClipboardRead(child.webContents);
     if (!this.tabsAsPopups) this.popup?.close();
     const size = this.pendingPopupSize ?? { width: 480, height: 360 };
@@ -642,7 +669,11 @@ export class BrowserController {
       },
       this.tabsAsPopups
         ? (details) => this.handleWindowOpen(details, child.webContents)
-        : undefined,
+        : ({ url }) => {
+            if (this.quitLink(url, child.webContents.id, "window-open")) return { action: "deny" };
+            void child.webContents.loadURL(url);
+            return { action: "deny" };
+          },
     );
     popup.onCursorChange = () => {
       if (this.popup === popup) this.onCursorChange?.(popup.cursorShape);
@@ -685,4 +716,3 @@ function browserRenderScale(layout: BrowserSurfaceLayout) {
   const cssPixels = layout.width * layout.height / (layout.scale * layout.scale);
   return Math.max(0.5, Math.min(layout.scale, Math.sqrt(maxPixels / cssPixels)));
 }
-

--- a/browser/src/page/quit-url.ts
+++ b/browser/src/page/quit-url.ts
@@ -1,0 +1,70 @@
+export const QUIT_URL = "terminal-browser://quit";
+
+export type QuitUrlRequest = "navigation" | "window-open" | "redirect";
+export type QuitUrlAction = "ignore" | "consume" | "close";
+
+export class QuitUrlPolicy {
+  constructor(
+    private readonly allowed: boolean,
+    private readonly primaryContentsId: number,
+  ) {}
+
+  request(
+    url: string,
+    requesterContentsId: number | undefined,
+    request: QuitUrlRequest,
+    initiatorContentsId?: number,
+  ): QuitUrlAction {
+    if (url !== QUIT_URL) return "ignore";
+    if (
+      request === "redirect" ||
+      !this.allowed ||
+      requesterContentsId !== this.primaryContentsId ||
+      (request === "navigation" && initiatorContentsId !== this.primaryContentsId)
+    ) {
+      return "consume";
+    }
+    return "close";
+  }
+}
+
+export function registerQuitUrlNavigationHandlers(
+  contents: Electron.WebContents,
+  resolveContents: (frame: Electron.WebFrameMain) => Electron.WebContents | undefined,
+  handle: (
+    url: string,
+    request: Extract<QuitUrlRequest, "navigation" | "redirect">,
+    targetContentsId: number | undefined,
+    initiatorContentsId: number | undefined,
+  ) => boolean,
+) {
+  const contentsId = (frame: Electron.WebFrameMain | null | undefined) => {
+    if (!frame) return undefined;
+    try {
+      if (frame.detached || frame.isDestroyed()) return undefined;
+      const resolved = resolveContents(frame);
+      return resolved && !resolved.isDestroyed() ? resolved.id : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  contents.on("will-frame-navigate", (event) => {
+    if (
+      handle(
+        event.url,
+        "navigation",
+        contentsId(event.frame),
+        contentsId(event.initiator),
+      )
+    ) {
+      event.preventDefault();
+    }
+  });
+  contents.on("will-redirect", (event) => {
+    if (
+      handle(event.url, "redirect", contentsId(event.frame), contentsId(event.initiator))
+    ) {
+      event.preventDefault();
+    }
+  });
+}

--- a/browser/src/session/contract.ts
+++ b/browser/src/session/contract.ts
@@ -1,0 +1,30 @@
+const APP_MODE_FLAGS = [
+  "--no-toolbar",
+  "--no-shortcuts",
+  "--no-context-menu",
+  "--no-overlays",
+  "--no-frame",
+  "--allow-clipboard-read",
+  "--open-tabs-in-popup-stack",
+];
+
+export function resolveSessionOptions(argv: string[]) {
+  const resolved = argv.includes("--app-mode") ? [...argv, ...APP_MODE_FLAGS] : argv;
+  return {
+    argv: resolved,
+    allowQuitUrl: resolved.includes("--allow-quit-url"),
+  };
+}
+
+export function ownsSender<T>(
+  senderFrame: T,
+  senderMainFrame: T,
+  senderId: number,
+  ownsContents: (id: number) => boolean,
+): boolean {
+  return senderFrame === senderMainFrame && ownsContents(senderId);
+}
+
+export function closeAction(tabCount: number): "shutdown" | "close" {
+  return tabCount <= 1 ? "shutdown" : "close";
+}

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -38,6 +38,7 @@ import type {
   PopupView,
 } from "../ui/types";
 import { normalizeUrl, searchOrUrl } from "../url";
+import { closeAction, ownsSender, resolveSessionOptions } from "./contract";
 import { bindingLabel, defaultKeys, isRecordKey, listStep, matchesBinding, parseKeyBindings, recordKeyLabel } from "./keybindings";
 import type { KeyBinding } from "./keybindings";
 import { clampDevtoolsFraction, computeLayout, dividerFraction, recordBarHeight } from "./layout";
@@ -75,16 +76,6 @@ export function createSession(ctx: SessionContext): SessionHandle {
 }
 
 const DEFAULT_URL = "https://github.com/zenbu-labs";
-
-const APP_MODE_FLAGS = [
-  "--no-toolbar",
-  "--no-shortcuts",
-  "--no-context-menu",
-  "--no-overlays",
-  "--no-frame",
-  "--allow-clipboard-read",
-  "--open-tabs-in-popup-stack",
-];
 
 const FONT_FILE = path.join("assets", "fonts", "JetBrainsMono-Regular.ttf");
 
@@ -162,6 +153,7 @@ class Session {
   private readonly noFrame: boolean;
   private readonly tabsAsPopups: boolean;
   private readonly clipboardRead: boolean;
+  private readonly allowQuitUrl: boolean;
   private readonly partition: string | null;
   private readonly socksPort: number | null;
   private readonly preload: string | null;
@@ -236,7 +228,9 @@ class Session {
     this.ctx = ctx;
     this.terminal = detect(ctx.env);
     this.marker = `terminal-browser:${ctx.key}`;
-    this.argv = ctx.argv.includes("--app-mode") ? [...ctx.argv, ...APP_MODE_FLAGS] : ctx.argv;
+    const options = resolveSessionOptions(ctx.argv);
+    this.argv = options.argv;
+    this.allowQuitUrl = options.allowQuitUrl;
     this.hideToolbar = this.argv.includes("--no-toolbar");
     this.noShortcuts = this.argv.includes("--no-shortcuts");
     this.noContextMenu = this.argv.includes("--no-context-menu");
@@ -269,6 +263,7 @@ class Session {
             this.partition,
             this.tabsAsPopups,
             this.clipboardRead,
+            this.allowQuitUrl,
             this.ctx.key,
             onState,
           ),
@@ -470,7 +465,7 @@ class Session {
   }
 
   private closeOrShutdown(id: number) {
-    if (this.tabs.count <= 1) this.shutdown();
+    if (closeAction(this.tabs.count) === "shutdown") this.shutdown();
     else this.tabs.close(id);
   }
 
@@ -521,12 +516,13 @@ class Session {
   }
 
   private ownsSender(event: IpcMainEvent): boolean {
-    if (event.senderFrame !== event.sender.mainFrame) return false;
-    let mine = false;
-    this.tabs.eachController((controller) => {
-      if (controller.hasContents(event.sender.id)) mine = true;
+    return ownsSender(event.senderFrame, event.sender.mainFrame, event.sender.id, (id) => {
+      let mine = false;
+      this.tabs.eachController((controller) => {
+        if (controller.hasContents(id)) mine = true;
+      });
+      return mine;
     });
-    return mine;
   }
 
   private broadcastTheme(): void {
@@ -1508,4 +1504,3 @@ function rememberUrl(url: string) {
     setLastUrl(url);
   } catch { }
 }
-

--- a/browser/test/electron-quit-url-fixture.js
+++ b/browser/test/electron-quit-url-fixture.js
@@ -1,0 +1,333 @@
+const http = require("node:http");
+
+const { app, BrowserWindow, webContents } = require("electron");
+const {
+  QUIT_URL,
+  QuitUrlPolicy,
+  registerQuitUrlNavigationHandlers,
+} = require("../dist/page/quit-url.js");
+
+const server = http.createServer((request, response) => {
+  if (request.url === "/redirect") {
+    response.writeHead(302, { location: QUIT_URL });
+    response.end();
+    return;
+  }
+  response.setHeader("content-type", "text/html");
+  if (request.url === "/frame") {
+    response.end("<!doctype html><title>frame</title>");
+    return;
+  }
+  response.end('<!doctype html><iframe src="/frame"></iframe>');
+});
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+}
+
+function waitForResult(run) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("quit URL event timed out")), 3000);
+    run((result) => {
+      clearTimeout(timeout);
+      resolve(result);
+    });
+  });
+}
+
+function policyHandler(policy, requester, rawUrl, resolve, reportProvenance = false) {
+  let closeAttempts = 0;
+  return {
+    decide(eventUrl, request, targetContentsId = requester.id, initiatorContentsId) {
+      const action = policy.request(
+        eventUrl,
+        targetContentsId,
+        request,
+        initiatorContentsId,
+      );
+      if (action === "close") closeAttempts++;
+      if (eventUrl.startsWith("terminal-browser:")) {
+        resolve({
+          rawUrl,
+          eventUrl,
+          request,
+          action,
+          closeAttempts,
+          ...(reportProvenance ? { targetContentsId, initiatorContentsId } : {}),
+        });
+      }
+      return action;
+    },
+  };
+}
+
+async function popupToOwnerCase(
+  port,
+  { allowed = true, popupHost = "127.0.0.1", nested = false, expression },
+) {
+  const owner = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  const ownerPolicy = new QuitUrlPolicy(allowed, owner.webContents.id);
+  owner.webContents.setWindowOpenHandler(() => ({ action: "allow" }));
+  await owner.loadURL(`http://127.0.0.1:${port}/page`);
+  await owner.webContents.executeJavaScript('window.name = "owner-target"');
+
+  const popupPromise = nextChild(owner.webContents);
+  await owner.webContents.executeJavaScript(
+    `void window.open("http://${popupHost}:${port}/popup")`,
+  );
+  const popup = await popupPromise;
+  let source = popup;
+  let nestedPopup;
+  if (nested) {
+    popup.webContents.setWindowOpenHandler(() => ({ action: "allow" }));
+    const nestedPromise = nextChild(popup.webContents);
+    await popup.webContents.executeJavaScript(
+      `void window.open("http://127.0.0.1:${port}/nested")`,
+    );
+    nestedPopup = await nestedPromise;
+    source = nestedPopup;
+  }
+
+  const ownerContentsId = owner.webContents.id;
+  const sourceContentsId = source.webContents.id;
+  const result = await waitForResult(async (resolve) => {
+    register(
+      owner.webContents,
+      policyHandler(ownerPolicy, owner.webContents, QUIT_URL, resolve, true),
+    );
+    await source.webContents.executeJavaScript(expression).catch(() => undefined);
+  });
+  nestedPopup?.destroy();
+  popup.destroy();
+  owner.destroy();
+  return { ...result, ownerContentsId, sourceContentsId };
+}
+
+function register(contents, handler) {
+  registerQuitUrlNavigationHandlers(
+    contents,
+    (frame) => webContents.fromFrame(frame),
+    (eventUrl, request, targetContentsId, initiatorContentsId) =>
+      handler.decide(eventUrl, request, targetContentsId, initiatorContentsId) !== "ignore",
+  );
+  contents.setWindowOpenHandler((details) => {
+    handler.decide(details.url, "window-open", contents.id);
+    return { action: "deny" };
+  });
+}
+
+async function frameOf(window) {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const frame = window.webContents.mainFrame.frames.find((candidate) => candidate !== window.webContents.mainFrame);
+    if (frame) return frame;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("iframe was not created");
+}
+
+async function primaryCase(port, { rawUrl, allowed, request }) {
+  const window = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  const result = await waitForResult(async (resolve) => {
+    const policy = new QuitUrlPolicy(allowed, window.webContents.id);
+    register(window.webContents, policyHandler(policy, window.webContents, rawUrl, resolve));
+    await window.loadURL(`http://127.0.0.1:${port}/page`);
+    const frame = await frameOf(window);
+    const expression =
+      request === "navigation"
+        ? `top.location.href = ${JSON.stringify(rawUrl)}`
+        : `void window.open(${JSON.stringify(rawUrl)})`;
+    await frame.executeJavaScript(expression).catch(() => undefined);
+  });
+  window.destroy();
+  return result;
+}
+
+async function redirectCase(port) {
+  const rawUrl = `http://127.0.0.1:${port}/redirect`;
+  const window = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  const result = await waitForResult(async (resolve) => {
+    const policy = new QuitUrlPolicy(true, window.webContents.id);
+    register(window.webContents, policyHandler(policy, window.webContents, rawUrl, resolve));
+    await window.loadURL(`http://127.0.0.1:${port}/page`);
+    const frame = await frameOf(window);
+    await frame.executeJavaScript(`top.location.href = ${JSON.stringify(rawUrl)}`).catch(() => undefined);
+  });
+  window.destroy();
+  return result;
+}
+
+function nextChild(contents) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("popup was not created")), 3000);
+    contents.once("did-create-window", (child) => {
+      clearTimeout(timeout);
+      resolve(child);
+    });
+  });
+}
+
+async function popupCases(port) {
+  const owner = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  const ownerPolicy = new QuitUrlPolicy(true, owner.webContents.id);
+  owner.webContents.setWindowOpenHandler(() => ({ action: "allow" }));
+  await owner.loadURL(`http://127.0.0.1:${port}/page`);
+
+  const popupPromise = nextChild(owner.webContents);
+  await owner.webContents.executeJavaScript(`void window.open("http://127.0.0.1:${port}/popup")`);
+  const popup = await popupPromise;
+
+  async function request(contents, kind) {
+    return waitForResult(async (resolve) => {
+      register(contents, policyHandler(ownerPolicy, contents, QUIT_URL, resolve));
+      const expression =
+        kind === "navigation"
+          ? `location.href = ${JSON.stringify(QUIT_URL)}`
+          : `void window.open(${JSON.stringify(QUIT_URL)})`;
+      await contents.executeJavaScript(expression).catch(() => undefined);
+    });
+  }
+
+  const popupNavigation = await request(popup.webContents, "navigation");
+  const popupWindowOpen = await request(popup.webContents, "window-open");
+
+  popup.webContents.setWindowOpenHandler(() => ({ action: "allow" }));
+  const nestedPromise = nextChild(popup.webContents);
+  await popup.webContents.executeJavaScript(`void window.open("http://127.0.0.1:${port}/nested")`);
+  const nested = await nestedPromise;
+  const nestedPopupNavigation = await request(nested.webContents, "navigation");
+  const nestedPopupWindowOpen = await request(nested.webContents, "window-open");
+
+  nested.destroy();
+  popup.destroy();
+  owner.destroy();
+  return { popupNavigation, popupWindowOpen, nestedPopupNavigation, nestedPopupWindowOpen };
+}
+
+async function foreignCase(port, allowed, ownerPolicy) {
+  const window = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  const result = await waitForResult(async (resolve) => {
+    const policy = ownerPolicy ?? new QuitUrlPolicy(allowed, window.webContents.id);
+    register(window.webContents, policyHandler(policy, window.webContents, QUIT_URL, resolve));
+    await window.loadURL(`http://127.0.0.1:${port}/page`);
+    const frame = await frameOf(window);
+    await frame.executeJavaScript(`top.location.href = ${JSON.stringify(QUIT_URL)}`).catch(() => undefined);
+  });
+  window.destroy();
+  return result;
+}
+
+app.on("window-all-closed", (event) => event.preventDefault());
+
+app.whenReady().then(async () => {
+  const port = await listen(server);
+  const output = {
+    defaultUpperNavigation: await primaryCase(port, {
+      rawUrl: "Terminal-browser://quit",
+      allowed: false,
+      request: "navigation",
+    }),
+    defaultUpperWindowOpen: await primaryCase(port, {
+      rawUrl: "Terminal-browser://quit",
+      allowed: false,
+      request: "window-open",
+    }),
+    optInUpperNavigation: await primaryCase(port, {
+      rawUrl: "Terminal-browser://quit",
+      allowed: true,
+      request: "navigation",
+    }),
+    optInUpperWindowOpen: await primaryCase(port, {
+      rawUrl: "Terminal-browser://quit",
+      allowed: true,
+      request: "window-open",
+    }),
+    variants: {},
+  };
+
+  for (const [name, rawUrl] of Object.entries({
+    hostCase: "terminal-browser://QUIT",
+    encodedHost: "terminal-browser://qu%69t",
+    slash: "terminal-browser://quit/",
+    path: "terminal-browser://quit/path",
+    query: "terminal-browser://quit?now",
+    fragment: "terminal-browser://quit#now",
+  })) {
+    output.variants[name] = await primaryCase(port, { rawUrl, allowed: true, request: "navigation" });
+  }
+
+  output.redirect = await redirectCase(port);
+  Object.assign(output, await popupCases(port));
+  output.crossOriginPopup = {
+    location: await popupToOwnerCase(port, {
+      popupHost: "localhost",
+      expression: `opener.location = ${JSON.stringify(QUIT_URL)}`,
+    }),
+    href: await popupToOwnerCase(port, {
+      popupHost: "localhost",
+      expression: `opener.location.href = ${JSON.stringify(QUIT_URL)}`,
+    }),
+    replace: await popupToOwnerCase(port, {
+      popupHost: "localhost",
+      expression: `opener.location.replace(${JSON.stringify(QUIT_URL)})`,
+    }),
+    namedTarget: await popupToOwnerCase(port, {
+      popupHost: "localhost",
+      expression: `void window.open(${JSON.stringify(QUIT_URL)}, "owner-target")`,
+    }),
+  };
+  output.sameOriginPopup = {
+    location: await popupToOwnerCase(port, {
+      expression: `opener.location = ${JSON.stringify(QUIT_URL)}`,
+    }),
+    replace: await popupToOwnerCase(port, {
+      expression: `opener.location.replace(${JSON.stringify(QUIT_URL)})`,
+    }),
+    namedTarget: await popupToOwnerCase(port, {
+      expression: `void window.open(${JSON.stringify(QUIT_URL)}, "owner-target")`,
+    }),
+    openerOpenNamed: await popupToOwnerCase(port, {
+      expression: `void opener.open(${JSON.stringify(QUIT_URL)}, "owner-target")`,
+    }),
+  };
+  output.nestedPopup = {
+    openerChain: await popupToOwnerCase(port, {
+      nested: true,
+      expression: `opener.opener.location = ${JSON.stringify(QUIT_URL)}`,
+    }),
+    namedTarget: await popupToOwnerCase(port, {
+      nested: true,
+      expression: `void window.open(${JSON.stringify(QUIT_URL)}, "owner-target")`,
+    }),
+  };
+  output.ownerRealm = {
+    navigationDefault: await popupToOwnerCase(port, {
+      allowed: false,
+      expression: `opener.eval(${JSON.stringify(`location = ${JSON.stringify(QUIT_URL)}`)})`,
+    }),
+    navigationOptIn: await popupToOwnerCase(port, {
+      expression: `opener.eval(${JSON.stringify(`location = ${JSON.stringify(QUIT_URL)}`)})`,
+    }),
+    windowOpenDefault: await popupToOwnerCase(port, {
+      allowed: false,
+      expression: `opener.eval(${JSON.stringify(`void window.open(${JSON.stringify(QUIT_URL)})`)})`,
+    }),
+    windowOpenOptIn: await popupToOwnerCase(port, {
+      expression: `opener.eval(${JSON.stringify(`void window.open(${JSON.stringify(QUIT_URL)})`)})`,
+    }),
+  };
+
+  const owner = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
+  const ownerPolicy = new QuitUrlPolicy(true, owner.webContents.id);
+  output.foreignNavigation = await foreignCase(port, true, ownerPolicy);
+  owner.destroy();
+  output.otherSessionNavigation = await foreignCase(port, false);
+
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  server.close(() => app.quit());
+}).catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  server.close(() => app.exit(1));
+});

--- a/browser/test/electron-quit-url.test.js
+++ b/browser/test/electron-quit-url.test.js
@@ -1,0 +1,113 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+function electronCommand() {
+  const electronRoot = path.dirname(require.resolve("electron/package.json"));
+  if (process.platform === "darwin") {
+    return [path.join(electronRoot, "dist", "Electron.app", "Contents", "MacOS", "Electron")];
+  }
+  return ["xvfb-run", "-a", path.join(electronRoot, "dist", "electron"), "--no-sandbox"];
+}
+
+test("Electron serialization feeds the production quit URL policy", () => {
+  const [command, ...prefix] = electronCommand();
+  const fixture = path.join(__dirname, "electron-quit-url-fixture.js");
+  const result = spawnSync(command, [...prefix, fixture], {
+    cwd: path.join(__dirname, ".."),
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = JSON.parse(result.stdout.trim().split("\n").at(-1));
+
+  assert.deepEqual(output.defaultUpperNavigation, {
+    rawUrl: "Terminal-browser://quit",
+    eventUrl: "terminal-browser://quit",
+    request: "navigation",
+    action: "consume",
+    closeAttempts: 0,
+  });
+  assert.deepEqual(output.defaultUpperWindowOpen, {
+    rawUrl: "Terminal-browser://quit",
+    eventUrl: "terminal-browser://quit",
+    request: "window-open",
+    action: "consume",
+    closeAttempts: 0,
+  });
+  assert.deepEqual(output.optInUpperNavigation, {
+    rawUrl: "Terminal-browser://quit",
+    eventUrl: "terminal-browser://quit",
+    request: "navigation",
+    action: "close",
+    closeAttempts: 1,
+  });
+  assert.deepEqual(output.optInUpperWindowOpen, {
+    rawUrl: "Terminal-browser://quit",
+    eventUrl: "terminal-browser://quit",
+    request: "window-open",
+    action: "close",
+    closeAttempts: 1,
+  });
+
+  const rejectedVariants = {
+    hostCase: "terminal-browser://QUIT",
+    encodedHost: "terminal-browser://qu%69t",
+    slash: "terminal-browser://quit/",
+    path: "terminal-browser://quit/path",
+    query: "terminal-browser://quit?now",
+    fragment: "terminal-browser://quit#now",
+  };
+  for (const [name, eventUrl] of Object.entries(rejectedVariants)) {
+    assert.equal(output.variants[name].eventUrl, eventUrl);
+    assert.equal(output.variants[name].action, "ignore");
+    assert.equal(output.variants[name].closeAttempts, 0);
+  }
+
+  for (const name of [
+    "popupNavigation",
+    "popupWindowOpen",
+    "nestedPopupNavigation",
+    "nestedPopupWindowOpen",
+    "foreignNavigation",
+    "otherSessionNavigation",
+  ]) {
+    assert.equal(output[name].eventUrl, "terminal-browser://quit", name);
+    assert.equal(output[name].action, "consume", name);
+    assert.equal(output[name].closeAttempts, 0, name);
+  }
+  assert.equal(output.redirect.eventUrl, "terminal-browser://quit");
+  assert.equal(output.redirect.request, "redirect");
+  assert.equal(output.redirect.action, "consume");
+  assert.equal(output.redirect.closeAttempts, 0);
+
+  for (const [group, cases] of Object.entries({
+    crossOriginPopup: output.crossOriginPopup,
+    sameOriginPopup: output.sameOriginPopup,
+    nestedPopup: output.nestedPopup,
+  })) {
+    for (const [name, result] of Object.entries(cases)) {
+      assert.equal(result.eventUrl, "terminal-browser://quit", `${group}.${name}`);
+      assert.equal(result.targetContentsId, result.ownerContentsId, `${group}.${name}`);
+      assert.equal(result.initiatorContentsId, result.sourceContentsId, `${group}.${name}`);
+      assert.notEqual(result.initiatorContentsId, result.ownerContentsId, `${group}.${name}`);
+      assert.equal(result.action, "consume", `${group}.${name}`);
+      assert.equal(result.closeAttempts, 0, `${group}.${name}`);
+    }
+  }
+
+  for (const name of ["navigationDefault", "windowOpenDefault"]) {
+    assert.equal(output.ownerRealm[name].action, "consume", name);
+    assert.equal(output.ownerRealm[name].closeAttempts, 0, name);
+  }
+  for (const name of ["navigationOptIn", "windowOpenOptIn"]) {
+    const result = output.ownerRealm[name];
+    assert.equal(result.action, "close", name);
+    assert.equal(result.closeAttempts, 1, name);
+    assert.equal(result.targetContentsId, result.ownerContentsId, name);
+    if (result.request === "navigation") {
+      assert.equal(result.initiatorContentsId, result.ownerContentsId, name);
+    }
+  }
+});

--- a/browser/test/quit-url.test.js
+++ b/browser/test/quit-url.test.js
@@ -1,0 +1,186 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { EventEmitter } = require("node:events");
+const {
+  QUIT_URL,
+  QuitUrlPolicy,
+  registerQuitUrlNavigationHandlers,
+} = require("../dist/page/quit-url.js");
+
+const PRIMARY = 11;
+
+test("quit URL recognition is literal equality at the Electron event boundary", () => {
+  const policy = new QuitUrlPolicy(true, PRIMARY);
+  const variants = [
+    "terminal-browser://quitter",
+    "terminal-browser://QUIT",
+    "terminal-browser://qu%69t",
+    "terminal-browser://quit/",
+    "terminal-browser://quit/path",
+    "terminal-browser://quit?now",
+    "terminal-browser://quit#now",
+  ];
+
+  for (const url of variants) {
+    assert.equal(policy.request(url, PRIMARY, "navigation", PRIMARY), "ignore", url);
+  }
+});
+
+test("default-off consumes exact navigation and window-open without closing", () => {
+  for (const kind of ["navigation", "window-open"]) {
+    const policy = new QuitUrlPolicy(false, PRIMARY);
+    assert.equal(policy.request(QUIT_URL, PRIMARY, kind), "consume");
+  }
+});
+
+test("default-off remains closed for requests from frames in the primary WebContents", () => {
+  for (const kind of ["navigation", "window-open"]) {
+    const policy = new QuitUrlPolicy(false, PRIMARY);
+    assert.equal(policy.request(QUIT_URL, PRIMARY, kind), "consume");
+  }
+});
+
+test("opt-in primary WebContents authorizes direct navigation and window-open", () => {
+  const policy = new QuitUrlPolicy(true, PRIMARY);
+  assert.equal(policy.request(QUIT_URL, PRIMARY, "navigation", PRIMARY), "close");
+  assert.equal(policy.request(QUIT_URL, PRIMARY, "window-open"), "close");
+});
+
+test("frames in the primary WebContents share the capability", () => {
+  const policy = new QuitUrlPolicy(true, PRIMARY);
+  assert.equal(policy.request(QUIT_URL, PRIMARY, "navigation", PRIMARY), "close");
+
+  const windowOpenPolicy = new QuitUrlPolicy(true, PRIMARY);
+  assert.equal(windowOpenPolicy.request(QUIT_URL, PRIMARY, "window-open"), "close");
+});
+
+test("popup, nested popup, and foreign WebContents are denied", () => {
+  for (const requester of [12, 13, 99]) {
+    const policy = new QuitUrlPolicy(true, PRIMARY);
+    assert.equal(policy.request(QUIT_URL, requester, "navigation", requester), "consume");
+  }
+});
+
+test("navigation requires target and initiator ownership", () => {
+  const policy = new QuitUrlPolicy(true, PRIMARY);
+  assert.equal(policy.request(QUIT_URL, PRIMARY, "navigation", 12), "consume");
+  assert.equal(policy.request(QUIT_URL, PRIMARY, "navigation"), "consume");
+  assert.equal(policy.request(QUIT_URL, undefined, "navigation", PRIMARY), "consume");
+});
+
+test("server redirects are consumed regardless of capability", () => {
+  for (const allowed of [false, true]) {
+    const policy = new QuitUrlPolicy(allowed, PRIMARY);
+    assert.equal(policy.request(QUIT_URL, PRIMARY, "redirect"), "consume");
+    assert.equal(policy.request(QUIT_URL, 12, "redirect"), "consume");
+  }
+});
+
+test("authorized requests remain retriable after a close veto", () => {
+  const policy = new QuitUrlPolicy(true, PRIMARY);
+  assert.equal(policy.request(QUIT_URL, PRIMARY, "navigation", PRIMARY), "close");
+  assert.equal(policy.request(QUIT_URL, PRIMARY, "window-open"), "close");
+});
+
+test("navigation wiring covers every frame and keeps redirects distinct", () => {
+  const contents = new EventEmitter();
+  const requests = [];
+  const targetFrame = { detached: false, isDestroyed: () => false };
+  const initiatorFrame = { detached: false, isDestroyed: () => false };
+  const target = { id: PRIMARY, isDestroyed: () => false };
+  const initiator = { id: PRIMARY, isDestroyed: () => false };
+  registerQuitUrlNavigationHandlers(
+    contents,
+    (frame) => new Map([[targetFrame, target], [initiatorFrame, initiator]]).get(frame),
+    (url, request, targetContentsId, initiatorContentsId) => {
+      requests.push({ url, request, targetContentsId, initiatorContentsId });
+      return url === QUIT_URL;
+    },
+  );
+
+  let navigationPrevented = 0;
+  contents.emit("will-frame-navigate", {
+    url: QUIT_URL,
+    isMainFrame: true,
+    frame: targetFrame,
+    initiator: initiatorFrame,
+    preventDefault: () => navigationPrevented++,
+  });
+  let redirectPrevented = 0;
+  contents.emit("will-redirect", {
+    url: QUIT_URL,
+    frame: targetFrame,
+    initiator: initiatorFrame,
+    preventDefault: () => redirectPrevented++,
+  });
+
+  assert.deepEqual(requests, [
+    {
+      url: QUIT_URL,
+      request: "navigation",
+      targetContentsId: PRIMARY,
+      initiatorContentsId: PRIMARY,
+    },
+    {
+      url: QUIT_URL,
+      request: "redirect",
+      targetContentsId: PRIMARY,
+      initiatorContentsId: PRIMARY,
+    },
+  ]);
+  assert.equal(navigationPrevented, 1);
+  assert.equal(redirectPrevented, 1);
+  assert.equal(contents.listenerCount("will-navigate"), 0);
+});
+
+test("navigation wiring fails closed for unavailable frame provenance", () => {
+  const contents = new EventEmitter();
+  const policy = new QuitUrlPolicy(true, PRIMARY);
+  const activeFrame = { detached: false, isDestroyed: () => false };
+  const detachedFrame = { detached: true, isDestroyed: () => false };
+  const destroyedFrame = { detached: false, isDestroyed: () => true };
+  const unresolvedFrame = { detached: false, isDestroyed: () => false };
+  const throwingFrame = { detached: false, isDestroyed: () => false };
+  const destroyedContentsFrame = { detached: false, isDestroyed: () => false };
+  const activeContents = { id: PRIMARY, isDestroyed: () => false };
+  const destroyedContents = { id: PRIMARY, isDestroyed: () => true };
+  const actions = [];
+  const resolved = new Map([
+    [activeFrame, activeContents],
+    [detachedFrame, activeContents],
+    [destroyedFrame, activeContents],
+    [destroyedContentsFrame, destroyedContents],
+  ]);
+  registerQuitUrlNavigationHandlers(
+    contents,
+    (frame) => {
+      if (frame === throwingFrame) throw new Error("frame detached during lookup");
+      return resolved.get(frame);
+    },
+    (url, request, targetContentsId, initiatorContentsId) => {
+      const action = policy.request(url, targetContentsId, request, initiatorContentsId);
+      actions.push(action);
+      return action !== "ignore";
+    },
+  );
+
+  for (const [frame, initiator] of [
+    [null, activeFrame],
+    [activeFrame, null],
+    [detachedFrame, activeFrame],
+    [activeFrame, destroyedFrame],
+    [unresolvedFrame, activeFrame],
+    [throwingFrame, activeFrame],
+    [destroyedContentsFrame, activeFrame],
+  ]) {
+    contents.emit("will-frame-navigate", {
+      url: QUIT_URL,
+      frame,
+      initiator,
+      preventDefault() {},
+    });
+  }
+
+  assert.deepEqual(actions, Array(7).fill("consume"));
+});

--- a/browser/test/session-contract.test.js
+++ b/browser/test/session-contract.test.js
@@ -1,0 +1,35 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  closeAction,
+  ownsSender,
+  resolveSessionOptions,
+} = require("../dist/session/contract.js");
+
+test("quit URL capability is absent by default and from app mode", () => {
+  assert.equal(resolveSessionOptions([]).allowQuitUrl, false);
+  const app = resolveSessionOptions(["--app-mode"]);
+  assert.equal(app.allowQuitUrl, false);
+  assert.equal(app.argv.includes("--allow-quit-url"), false);
+});
+
+test("quit URL capability requires its explicit flag", () => {
+  assert.equal(resolveSessionOptions(["--allow-quit-url"]).allowQuitUrl, true);
+});
+
+test("verified IPC accepts only an owning main frame", () => {
+  const mainFrame = {};
+  const subframe = {};
+  const ownsContents = (id) => id === 11;
+
+  assert.equal(ownsSender(mainFrame, mainFrame, 11, ownsContents), true);
+  assert.equal(ownsSender(subframe, mainFrame, 11, ownsContents), false);
+  assert.equal(ownsSender(mainFrame, mainFrame, 12, ownsContents), false);
+  assert.equal(ownsSender(mainFrame, mainFrame, 99, ownsContents), false);
+});
+
+test("existing tab lifecycle shuts down only for the last tab", () => {
+  assert.equal(closeAction(1), "shutdown");
+  assert.equal(closeAction(2), "close");
+});

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsc -p tsconfig.json && node --test \"test/*.test.js\""
   },
   "dependencies": {
     "pixel-store": "workspace:*",

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -39,6 +39,14 @@ Options:
                         page instead.
   --allow-clipboard-read
                         Lets websites read from clipboard.
+  --allow-quit-url      Lets the primary page WebContents close its owning tab when
+                        Electron reports exactly terminal-browser://quit. Disabled
+                        by default. Raw spellings that Electron serializes to that
+                        same string are treated identically. All frames in that
+                        WebContents share the capability. Requests observed as
+                        originating from popup or foreign WebContents are denied,
+                        as are redirects. Under normal browser same-origin semantics,
+                        code executing in the owning page retains its capability.
   --no-toolbar          No toolbar or tab strip
   --no-shortcuts        No browser shortcuts, keys go to the page
   --no-context-menu     No right-click menu

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -21,6 +21,7 @@ import { commandHelp, helpTopics, rootHelp } from "./help";
 import { browsers, describe, recordKey } from "./instances";
 import type { Browser } from "./instances";
 import { lsCommand } from "./ls";
+import { isBrowserFlag } from "./open-flags";
 import { instances } from "./registry";
 import { apparmorSetup, deniedRefusal, linuxSandboxError, sandboxRefusal } from "./sandbox";
 import { openSshTunnel, startBundle, validateBundleDir, validateSshTarget } from "./ssh";
@@ -463,36 +464,10 @@ async function requireGraphics(check: TerminalCheck) {
   process.exit(1);
 }
 
-const BROWSER_FLAGS = [
-  "--app-mode",
-  "--no-toolbar",
-  "--no-shortcuts",
-  "--no-context-menu",
-  "--no-overlays",
-  "--no-frame",
-  "--open-tabs-in-popup-stack",
-  "--allow-clipboard-read",
-  "--partition=",
-  "--ssh=",
-  "--ssh-bundle=",
-  "--ssh-bundle-dir=",
-  "--preload=",
-  "--main-script=",
-  "--palette-key=",
-  "--find-key=",
-  "--devtools-key=",
-  "--console-key=",
-  "--split-dir=",
-  "--parent-tty=",
-];
-
 function rejectUnknownFlags(args: string[]) {
   for (const arg of args) {
     if (!arg.startsWith("-")) continue;
-    const known = BROWSER_FLAGS.some((flag) =>
-      flag.endsWith("=") ? arg.startsWith(flag) : arg === flag,
-    );
-    if (!known) fail(`unknown option ${arg.split("=")[0]} (terminal-browser open --help)`);
+    if (!isBrowserFlag(arg)) fail(`unknown option ${arg.split("=")[0]} (terminal-browser open --help)`);
   }
 }
 

--- a/cli/src/open-flags.ts
+++ b/cli/src/open-flags.ts
@@ -1,0 +1,29 @@
+const BROWSER_FLAGS = [
+  "--app-mode",
+  "--no-toolbar",
+  "--no-shortcuts",
+  "--no-context-menu",
+  "--no-overlays",
+  "--no-frame",
+  "--open-tabs-in-popup-stack",
+  "--allow-clipboard-read",
+  "--allow-quit-url",
+  "--partition=",
+  "--ssh=",
+  "--ssh-bundle=",
+  "--ssh-bundle-dir=",
+  "--preload=",
+  "--main-script=",
+  "--palette-key=",
+  "--find-key=",
+  "--devtools-key=",
+  "--console-key=",
+  "--split-dir=",
+  "--parent-tty=",
+];
+
+export function isBrowserFlag(arg: string): boolean {
+  return BROWSER_FLAGS.some((flag) =>
+    flag.endsWith("=") ? arg.startsWith(flag) : arg === flag,
+  );
+}

--- a/cli/test/open-flags.test.js
+++ b/cli/test/open-flags.test.js
@@ -1,0 +1,20 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { isBrowserFlag } = require("../dist/open-flags.js");
+
+test("allow-quit-url is accepted explicitly", () => {
+  assert.equal(isBrowserFlag("--allow-quit-url"), true);
+});
+
+test("upstream SSH browser flags remain accepted after flag registry extraction", () => {
+  assert.equal(isBrowserFlag("--ssh=dev@build-box"), true);
+  assert.equal(isBrowserFlag("--ssh-bundle=/tmp/app"), true);
+  assert.equal(isBrowserFlag("--ssh-bundle-dir=/srv/app"), true);
+});
+
+test("unknown option protection remains fail closed", () => {
+  assert.equal(isBrowserFlag("--allow-quit-url=true"), false);
+  assert.equal(isBrowserFlag("--allow-quit-urls"), false);
+  assert.equal(isBrowserFlag("--unknown"), false);
+});


### PR DESCRIPTION
## 概要

`terminal-browser://quit`をdefault-offの明示的なlifecycle capabilityに変更します。

- `--allow-quit-url`を指定したSessionだけが利用可能
- Electronがmain-process policy hookへ渡すURLが`terminal-browser://quit`と完全一致する場合だけ認識
- navigationではtarget frameとinitiator frameの双方が、当該`BrowserController`のprimary `WebContents`に属する場合だけcloseを要求可能
- `window.open`ではhandlerを処理するrequesting `WebContents`がprimary `WebContents`の場合だけcloseを要求可能
- redirectと、popup・nested popup・foreign `WebContents`として観測されるrequestはconsumeしてcloseしない
- `--app-mode`、`--preload`、`--main-script`からは暗黙に有効化しない

## Root cause

従来はrenderer-controlled URLをprefix一致だけでprivileged lifecycle actionへ接続し、明示的なSession authority、target ownership、initiator ownershipを確認していませんでした。このため通常のweb contentやpopupがowning tabを閉じ、last tabではSession shutdownへ到達できました。

## URL / WebContents contract

recognition boundaryはElectron eventのserialized URL stringです。application側ではURL parse、decode、case folding、component stripping、prefix matchingを行いません。

Electron 43ではraw `Terminal-browser://quit`がevent上の`terminal-browser://quit`へcanonicalizeされるため同じcommandとして扱います。一方、path/query/fragment/percent-encoded variantsはserialized valueが異なる限り認識しません。

primary `WebContents`配下の全frameは同じcapability domainを共有します。direct navigationは`will-frame-navigate`、server redirectは`will-redirect`、window openは`setWindowOpenHandler`で処理します。frame provenanceを解決できない場合はfail closedです。

requests observed as originating from popup or foreign `WebContents` are denied. Same-origin code executing in the owning page retains the owning page's capability under normal browser same-origin semantics. 完全なcausal popup isolationやopener isolationは本変更の境界ではありません。

## Verification

Current rebased head `f59c94c3d057328eba65c3400f885c98ee7dd216` has parent `cce10b6131d15bf46a3e4b8dc827e0544ff7fc65` (current upstream `main`). Upstream SSH/session/CLI drift was reconciled while preserving the quit-URL authorization boundary.

- browser focused tests: 15/15 passed
- CLI focused tests: 3/3 passed
- Electron integration: 1/1 passed
- `pnpm -r typecheck`: passed
- `pnpm build`: passed
- `git diff --check`: passed
- actual `terminal-code@4e7c635349ad1cff0dd22a49ffa4cc066c55a7dc` E2E: passed
- Codex Security finalized: findings 0, changed-file coverage 15/15, deferred 0, exclusions 0

Repo-wide `pnpm -r test` did not start the test suite because the pnpm execution environment returned `unable to open database file`. The same pre-test failure reproduced on both candidate `f59c94c3d057328eba65c3400f885c98ee7dd216` and clean upstream `cce10b6131d15bf46a3e4b8dc827e0544ff7fc65`; this is not recorded as a full-suite pass or a candidate-only regression.

## Compatibility / release sequencing

Current `zenbu-labs/terminal-code@4e7c635349ad1cff0dd22a49ffa4cc066c55a7dc` pins terminal-browser `main-2a739b3`. Its launch arguments are `--app-mode`, `--preload`, and `--main-script`; it does not pass `--allow-quit-url`. Its quit transport continues to call `openExternal("terminal-browser://quit")`.

The actual-consumer E2E preserved the existing transport: without the flag the exact URL was consumed with close attempt 0; with the flag, owner target/initiator provenance produced close attempt 1. Existing `window.close()` / `beforeunload` semantics remain unchanged, so the current VS Code page can veto actual tab close and Session shutdown.

Merging this PR alone does not grant the current consumer the capability. A future terminal-code consumer update must deliberately adopt a terminal-browser version containing this change and add `--allow-quit-url` together. This PR does not make that terminal-code change.
