### PR TITLE
feat: add NixOS packaging and installation and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ A real browser that runs inside your terminal
 curl -fsSl https://terminal-browser.sh/install | bash
 ```
 
+On NixOS, run it directly from this repository:
+
+```bash
+nix run github:zenbu-labs/terminal-browser
+```
+
+Or install it into your profile:
+
+```bash
+nix profile install github:zenbu-labs/terminal-browser
+```
+
+The flake also exports `packages.<system>.terminal-browser`, so it can be added to
+`environment.systemPackages` or `home.packages` with the package manager of your choice.
+
 ### Usage
 ```
 terminal-browser # launches the browser

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "A real browser that runs inside your terminal";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forEachSystem (pkgs:
+        let
+          terminal-browser = pkgs.callPackage ./nix/package.nix { };
+        in
+        {
+          default = terminal-browser;
+          inherit terminal-browser;
+        });
+
+      apps = forEachSystem (pkgs: {
+        default = {
+          type = "app";
+          program = "${pkgs.callPackage ./nix/package.nix { }}/bin/terminal-browser";
+          meta.description = "Run terminal-browser";
+        };
+      });
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  alsa-lib,
+  at-spi2-atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libdrm,
+  libgbm,
+  libGL,
+  libnotify,
+  libpulseaudio,
+  libsecret,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxkbcommon,
+  libxkbfile,
+  libxrandr,
+  libxshmfence,
+  nspr,
+  nss,
+  pango,
+  pciutils,
+  pipewire,
+  speechd-minimal,
+  systemd,
+  vulkan-loader,
+}:
+
+let
+  version = "0.5.8";
+  releases = {
+    x86_64-linux = {
+      target = "linux-x64";
+      hash = "sha256-wzC+M0Hvb2yxBuT7MsHWB1Sgjhp2QRQ6empNnpRI9hc=";
+    };
+    aarch64-linux = {
+      target = "linux-arm64";
+      hash = "sha256-n/5/wfKjCe0L5IwvNfulNPOBY9ZMIsDH3FOZSdTxnnE=";
+    };
+  };
+  release = releases.${stdenv.hostPlatform.system};
+  runtimeLibraries = [
+    alsa-lib
+    at-spi2-atk
+    cairo
+    cups
+    dbus
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libGL
+    libnotify
+    libpulseaudio
+    libsecret
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxkbcommon
+    libxkbfile
+    libxrandr
+    libxshmfence
+    nspr
+    nss
+    pango
+    pciutils
+    pipewire
+    speechd-minimal
+    stdenv.cc.cc
+    systemd
+    vulkan-loader
+  ];
+in
+stdenv.mkDerivation {
+  pname = "terminal-browser";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://terminal-browser.sh/install/dl/stable/v${version}/terminal-browser-${release.target}.tar.gz";
+    inherit (release) hash;
+  };
+
+  sourceRoot = "terminal-browser";
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  buildInputs = runtimeLibraries;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/terminal-browser" "$out/bin"
+    cp -R . "$out/lib/terminal-browser"
+    makeWrapper "$out/lib/terminal-browser/bin/terminal-browser" "$out/bin/terminal-browser"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Real browser that runs inside your terminal";
+    homepage = "https://terminal-browser.sh";
+    license = lib.licenses.mit;
+    mainProgram = "terminal-browser";
+    platforms = builtins.attrNames releases;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
The standard Linux release bundles dynamically linked Electron binaries. These binaries cannot run directly on NixOS because their expected runtime libraries and dynamic linker are not available through conventional filesystem paths.

This adds a Nix flake that packages the official terminal-browser release so NixOS users can run, install, and distribute the CLI through standard Nix workflows.

## Changes

- Add `flake.nix` with packages and a default app for `x86_64-linux` and `aarch64-linux`.
- Add `flake.lock` to pin the nixpkgs revision used to build the package.
- Add `nix/package.nix` to download the official terminal-browser v0.5.8 release for each architecture.
- Verify release archives with pinned SHA-256 hashes.
- Patch Electron and the native Node module for the Nix store with `autoPatchelfHook`.
- Provide the `terminal-browser` executable through the package's `bin` directory.
- Document direct execution and profile installation in `README.md`.

The package uses the project's official patched Electron release instead of replacing it with the Electron package from nixpkgs.

## Verification

The following checks were completed on NixOS:

```bash
nix flake check path:. --all-systems --no-build
nix build path:.#terminal-browser --no-link
nix run path:. -- --help
nix run path:. -- --version
```

## Usage

Run directly from GitHub:

```bash
nix run github:zenbu-labs/terminal-browser
```

Run a local checkout:

```bash
nix run path:.
```

Pass CLI arguments after `--`:

```bash
nix run path:. -- --help
nix run path:. -- open https://example.com
```

Install into a user profile:

```bash
nix profile install github:zenbu-labs/terminal-browser
```

## NixOS Configuration

Add the repository as a flake input and include its package in `environment.systemPackages`:

```nix
{
  inputs.terminal-browser.url = "github:zenbu-labs/terminal-browser";

  outputs = { nixpkgs, terminal-browser, ... }: {
    nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        {
          environment.systemPackages = [
            terminal-browser.packages.x86_64-linux.default
          ];
        }
      ];
    };
  };
}
```

Apply the configuration with:

```bash
sudo nixos-rebuild switch --flake .#your-hostname
```

Use `aarch64-linux` instead of `x86_64-linux` on ARM64 systems.

