### PR TITLE
feat(terminals): add zellij pane adapter

### DIFF
--- a/terminals/src/terminals/index.ts
+++ b/terminals/src/terminals/index.ts
@@ -8,6 +8,7 @@ import { tmux } from "./tmux";
 import { tty7 } from "./tty7";
 import { vscode } from "./vscode";
 import { wezterm } from "./wezterm";
+import { zellij } from "./zellij";
 
 /**
  * not fantastic, but ordering does matter
@@ -15,6 +16,7 @@ import { wezterm } from "./wezterm";
 export const TERMINALS: Detect[] = [
   herdr,
   tmux,
+  zellij,
   tty7,
   wezterm,
   kitty,

--- a/terminals/src/terminals/zellij.ts
+++ b/terminals/src/terminals/zellij.ts
@@ -1,0 +1,53 @@
+import type { Detect, Direction } from "../terminal";
+
+interface ZellijPane {
+  id: number;
+  tab_id: number;
+}
+
+const NATIVE_DIRECTION: Record<Direction, "right" | "down"> = {
+  right: "right",
+  left: "right",
+  down: "down",
+  up: "down",
+};
+
+const OPPOSITE: Record<"right" | "down", "left" | "up"> = { right: "left", down: "up" };
+
+export const zellij: Detect = (env, run) => {
+  if (!env.ZELLIJ) return null;
+
+  const zellij = (args: string[]) => run("zellij", args);
+
+  async function panes(): Promise<ZellijPane[]> {
+    return JSON.parse(await zellij(["action", "list-panes", "-j"])) as ZellijPane[];
+  }
+
+  async function currentTab(): Promise<string | null> {
+    const selfId = Number(env.ZELLIJ_PANE_ID);
+    const pane = (await panes()).find((candidate) => candidate.id === selfId);
+    return pane ? String(pane.tab_id) : null;
+  }
+
+  return {
+    name: "zellij",
+    async getCurrentPane() {
+      if (!env.ZELLIJ_PANE_ID) return null;
+      const tab = await currentTab();
+      return tab ? { id: env.ZELLIJ_PANE_ID, tab } : null;
+    },
+    async split({ from, direction, command }) {
+      const native = NATIVE_DIRECTION[direction];
+      try {
+        await zellij(["action", "focus-pane-id", from.id]);
+      } catch {
+      }
+      const output = await zellij(["action", "new-pane", "-d", native, "--", ...command]);
+      const created = output.match(/terminal_\d+/)?.[0];
+      if (!created) return;
+      if (direction === "left" || direction === "up") {
+        await zellij(["action", "move-pane", "-p", created, OPPOSITE[native]]);
+      }
+    },
+  };
+};


### PR DESCRIPTION
## Problem

`terminal-browser` fails to open when run inside a [zellij](https://zellij.dev) session, even though it works fine outside one on the same terminal:

```
$ terminal-browser open about:blank
terminal-browser: could not find this pane in Ghostty — we marked /dev/ttys004 and
no Ghostty pane reported it back, so /dev/ttys004 is not a Ghostty pane
(a shell inside tmux or a remote session looks like this)
```

## Root cause

`terminals/src/terminals/index.ts`'s `TERMINALS` list has adapters for tmux, kitty, wezterm, ghostty, etc., but nothing for zellij.

When zellij runs nested inside a GUI terminal (e.g. Ghostty), it doesn't strip vars like `TERM_PROGRAM` from the shells it spawns, so `TERM_PROGRAM=ghostty` leaks through to panes inside the zellij session. Since `ghostty` is checked before there's any zellij-aware adapter, it wrongly claims the terminal. Its `getCurrentPane` identifies "this pane" via AppleScript against Ghostty's own window/tab/terminal list — but Ghostty only has *one* real terminal surface for the entire zellij session (the one running zellij itself), with no visibility into zellij's internal panes. The marker-directory match it relies on can never succeed, hence the error above.

## Fix

Adds a `zellij` adapter, self-contained via zellij's own CLI (same approach as the existing `tmux` adapter — no GUI automation needed), and registers it immediately after `tmux` in the detection order so a multiplexer's own env var wins over a leaked outer `TERM_PROGRAM`.

- `getCurrentPane` uses `$ZELLIJ_PANE_ID` directly for self-identification (no marker/tty matching needed — zellij tells us our own pane id), resolving the tab via `zellij action list-panes -j`.
- `split` uses `zellij action new-pane -d right|down -- <command>`. Since `new-pane` only supports `right`/`down` natively, `left`/`up` requests map to the opposite native direction and then relocate the new pane via `zellij action move-pane -p <id> <direction>`.
- `zellij action focus-pane-id` (used to make `new-pane` originate from the intended pane, since `new-pane` has no target-pane flag) is best-effort — it exits non-zero when the target is already focused, which is the common case, so a failure there doesn't abort the split. Same pattern as `prepareTmux`'s best-effort tmux calls in `tmux.ts`.
- `size` isn't honored — zellij's `new-pane` has no ratio/percentage flag for tiled panes, same as other adapters that can't fulfill every `SplitRequest` field.

## Verification

Tested live against a real zellij session nested in Ghostty (the exact failure environment):

- `detect()` now resolves to the `zellij` adapter instead of erroring via the `ghostty` path.
- `getCurrentPane()` correctly self-identifies, cross-checked against `zellij action list-panes -j`.
- `split()` for all four directions creates a real pane in the correct position (verified via pane `pane_x` before/after) and cleans up correctly.
- `pnpm --filter pixel-terminals build` / `typecheck` — clean.
- `terminals`' own test suite — no regressions (one pre-existing unrelated `herdr` failure, confirmed present on `main` before this change too).

No changes to `terminal.ts` or `shared.ts` — the existing `Detect`/`Terminal` contract was sufficient.
