### PR TITLE
Implement ssh proxy option for network requests

### DIFF
--- a/browser/src/page/browser-session.ts
+++ b/browser/src/page/browser-session.ts
@@ -98,6 +98,29 @@ export function configureBrowserSession(
   return target;
 }
 
+const socksProxied = new WeakSet<Session>();
+let webrtcGuardInstalled = false;
+
+export async function routeThroughSocksProxy(
+  partition: string | null,
+  port: number,
+): Promise<void> {
+  const target = browserSession(partition);
+  socksProxied.add(target);
+  if (!webrtcGuardInstalled) {
+    webrtcGuardInstalled = true;
+    app.on("web-contents-created", (_event, contents) => {
+      if (socksProxied.has(contents.session)) {
+        contents.setWebRTCIPHandlingPolicy("disable_non_proxied_udp");
+      }
+    });
+  }
+  await target.setProxy({
+    proxyRules: `socks5://127.0.0.1:${port}`,
+    proxyBypassRules: "<-loopback>",
+  });
+}
+
 export function browserSession(partition: string | null): Session {
   return partition ? session.fromPartition(persistentPartition(partition)) : session.defaultSession;
 }

--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -546,7 +546,9 @@ export class BrowserController {
 
   private async loadFavicon(urls: string[]) {
     const seq = ++this.faviconSeq;
-    const file = await this.favicons.resolve(urls).catch(() => null);
+    const file = await this.favicons
+      .resolve(urls, this.window.webContents.session)
+      .catch(() => null);
     if (file && seq === this.faviconSeq) this.updateState({ favicon: file });
   }
 

--- a/browser/src/page/favicon.ts
+++ b/browser/src/page/favicon.ts
@@ -2,23 +2,28 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
-import { net, nativeImage } from "electron";
+import { nativeImage } from "electron";
+import type { Session } from "electron";
 
 import { FAVICONS_DIR } from "pixel-store";
 
 export class FaviconCache {
   constructor(private readonly dir: string = FAVICONS_DIR) {}
 
-  async resolve(urls: string[]): Promise<string | null> {
+  async resolve(urls: string[], ses: Session): Promise<string | null> {
     const url = urls.find((u) => /\.(png|jpe?g|webp)(\?|$)/i.test(u)) ?? urls[0];
     if (!url) return null;
     const stem = path.join(
       this.dir,
-      crypto.createHash("sha1").update(url).digest("hex").slice(0, 16),
+      crypto
+        .createHash("sha1")
+        .update(`${ses.storagePath ?? ""}\0${url}`)
+        .digest("hex")
+        .slice(0, 16),
     );
     const cached = [`${stem}.png`, `${stem}.ico`].find((file) => fs.existsSync(file));
     if (cached) return cached;
-    const response = await net.fetch(url);
+    const response = await ses.fetch(url);
     if (!response.ok) return null;
     const data = Buffer.from(await response.arrayBuffer());
     if (data.length === 0) return null;

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -9,7 +9,11 @@ import type { DragEvent, EngineKeyEvent, PixelRoot, Surface } from "pixel-react"
 import { detect } from "pixel-terminals";
 import type { Pane, Terminal } from "pixel-terminals";
 
-import { browserSession, configureBrowserSession } from "../page/browser-session";
+import {
+  browserSession,
+  configureBrowserSession,
+  routeThroughSocksProxy,
+} from "../page/browser-session";
 import type { DownloadProgress } from "../page/browser-session";
 import { BrowserController } from "../page/controller";
 import { initOffscreenMode } from "../page/offscreen";
@@ -159,6 +163,7 @@ class Session {
   private readonly tabsAsPopups: boolean;
   private readonly clipboardRead: boolean;
   private readonly partition: string | null;
+  private readonly socksPort: number | null;
   private readonly preload: string | null;
   private readonly mainScript: string | null;
   private readonly onThemeRequest = (event: IpcMainEvent) => {
@@ -239,7 +244,12 @@ class Session {
     this.noFrame = this.argv.includes("--no-frame");
     this.tabsAsPopups = this.argv.includes("--open-tabs-in-popup-stack");
     this.clipboardRead = this.argv.includes("--allow-clipboard-read");
-    this.partition = flagValue(this.argv, "--partition");
+    const sshTarget = flagValue(this.argv, "--ssh");
+    const socksPort = Number(flagValue(this.argv, "--socks-port"));
+    this.socksPort = Number.isInteger(socksPort) && socksPort > 0 ? socksPort : null;
+    this.partition =
+      flagValue(this.argv, "--partition") ??
+      (sshTarget ? `ssh-${sshTarget.replace(/[^A-Za-z0-9@._-]/g, "-")}` : null);
     this.preload = flagValue(this.argv, "--preload");
     this.mainScript = flagValue(this.argv, "--main-script");
     this.fallbackState = initialBrowserState(this.initialUrl());
@@ -297,6 +307,7 @@ class Session {
   }
 
   async start(): Promise<void> {
+    if (this.socksPort) await routeThroughSocksProxy(this.partition, this.socksPort);
     if (process.platform === "darwin") app.dock?.hide();
     await this.loadDevtoolsSettings();
     if (!this.ctx.tty) process.stdout.write(`\x1b]2;${this.marker}\x07`);

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -22,7 +22,7 @@ Options:
                         proxy the result back to the local terminal-browser instance
   --ssh-bundle <dir>    Install and execute a bundle on a remote server. This is useful when paired with
                         --app-mode and --ssh, allowing you to run an application server on a
-                        remote mahine, then view the output over ssh
+                        remote machine, then view the output over ssh
   --ssh-bundle-dir <dir>
                         The path --ssh-bundle should be installed to through the ssh server. Defaults to
                         \${XDG_DATA_HOME:-~/.local/share}/terminal-browser/bundles

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -23,6 +23,9 @@ Options:
   --ssh-bundle <dir>    Install and execute a bundle on a remote server. This is useful when paired with
                         --app-mode and --ssh, allowing you to run an application server on a
                         remote mahine, then view the output over ssh
+  --ssh-bundle-dir <dir>
+                        The path --ssh-bundle should be installed to through the ssh server. Defaults to
+                        \${XDG_DATA_HOME:-~/.local/share}/terminal-browser/bundles
   --preload=<path>      Run a script inside the context of a web page before it loads (uses electron's preload feature under the hood, runs in an isolated world).
                         terminal-browser specific api's are exposed on globalThis.terminalBrowser
                         {

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -18,6 +18,11 @@ The url can be a normal url, a localhost port, or a path to an html file.
 Options:
   --split <direction>   Open in a new pane: right, left, down, up
   --size <fraction>     How much of the space the split takes (0.2 to 0.95)
+  --ssh <user@host>     Perform all network requests through a remote server, then
+                        proxy the result back to the local terminal-browser instance
+  --ssh-bundle <dir>    Install and execute a bundle on a remote server. This is useful when paired with
+                        --app-mode and --ssh, allowing you to run an application server on a
+                        remote mahine, then view the output over ssh
   --preload=<path>      Run a script inside the context of a web page before it loads (uses electron's preload feature under the hood, runs in an isolated world).
                         terminal-browser specific api's are exposed on globalThis.terminalBrowser
                         {
@@ -44,6 +49,7 @@ Examples:
   terminal-browser open localhost:3000
   terminal-browser open ./report.html --split right
   terminal-browser open github.com/zenbu-labs --split down --size 0.4
+  terminal-browser open --ssh dev@build-box localhost:8080
 `,
   },
   ls: {

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -358,7 +358,8 @@ async function sshSetup(argv: string[]): Promise<void> {
   argv.push(`--socks-port=${tunnel.socksPort}`);
   const bundleDir = flagEq(argv, "--ssh-bundle");
   if (bundleDir) {
-    bundle = await startBundle(tunnel, bundleDir, status);
+    const remoteBase = flagEq(argv, "--ssh-bundle-dir");
+    bundle = await startBundle(tunnel, bundleDir, status, remoteBase || undefined);
     if (!argv.some((arg) => !arg.startsWith("-"))) argv.unshift(bundle.url);
   }
   for (const signal of signals) process.removeListener(signal, interrupt);
@@ -474,6 +475,7 @@ const BROWSER_FLAGS = [
   "--partition=",
   "--ssh=",
   "--ssh-bundle=",
+  "--ssh-bundle-dir=",
   "--preload=",
   "--main-script=",
   "--palette-key=",
@@ -503,8 +505,13 @@ function takeSshFlags(args: string[]): void {
   if (at >= 0) {
     args[at] = `--ssh-bundle=${path.resolve(args[at].slice("--ssh-bundle=".length))}`;
   }
+  const bundleDir = takeFlag(args, "--ssh-bundle-dir");
+  if (bundleDir !== undefined) args.push(`--ssh-bundle-dir=${bundleDir}`);
   const target = args.find((arg) => arg.startsWith("--ssh="))?.slice("--ssh=".length);
   if (at >= 0 && !target) fail("--ssh-bundle needs --ssh");
+  if (args.some((arg) => arg.startsWith("--ssh-bundle-dir=")) && at < 0) {
+    fail("--ssh-bundle-dir needs --ssh-bundle");
+  }
   try {
     if (target) parseSshTarget(target);
     if (at >= 0) validateBundleDir(args[at].slice("--ssh-bundle=".length));

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -23,6 +23,8 @@ import type { Browser } from "./instances";
 import { lsCommand } from "./ls";
 import { instances } from "./registry";
 import { apparmorSetup, deniedRefusal, linuxSandboxError, sandboxRefusal } from "./sandbox";
+import { openSshTunnel, parseSshTarget, startBundle, validateBundleDir } from "./ssh";
+import type { RemoteBundle } from "./ssh";
 import type { InstanceRecord } from "./registry";
 import { installedVersion, upgradeCommand } from "./upgrade";
 
@@ -323,11 +325,43 @@ async function attachHere(argv: string[]): Promise<never> {
   };
   process.on("SIGINT", requestClose);
   process.on("SIGTERM", requestClose);
+  process.on("SIGHUP", requestClose);
   return new Promise<never>(() => {});
 }
 
 async function openHere(argv: string[]): Promise<never> {
+  await sshSetup(argv).catch((error) =>
+    fail(error instanceof Error ? error.message : String(error)),
+  );
   return attachHere(argv).catch((error) => fail(`could not start the browser: ${String(error)}`));
+}
+
+function flagEq(argv: string[], flag: string): string | undefined {
+  return argv.find((arg) => arg.startsWith(`${flag}=`))?.slice(flag.length + 1);
+}
+
+async function sshSetup(argv: string[]): Promise<void> {
+  const target = flagEq(argv, "--ssh");
+  if (!target) return;
+  const status = (line: string) => process.stdout.write(`ssh: ${line}\n`);
+  const interrupt = () => process.exit(130);
+  const signals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+  for (const signal of signals) process.on(signal, interrupt);
+  let bundle: RemoteBundle | null = null;
+  const tunnel = await openSshTunnel(target, status);
+  process.on("exit", () => {
+    try {
+      bundle?.stop();
+    } catch {}
+    tunnel.stop();
+  });
+  argv.push(`--socks-port=${tunnel.socksPort}`);
+  const bundleDir = flagEq(argv, "--ssh-bundle");
+  if (bundleDir) {
+    bundle = await startBundle(tunnel, bundleDir, status);
+    if (!argv.some((arg) => !arg.startsWith("-"))) argv.unshift(bundle.url);
+  }
+  for (const signal of signals) process.removeListener(signal, interrupt);
 }
 
 const DIRECTIONS: Direction[] = ["right", "left", "down", "up"];
@@ -373,7 +407,9 @@ async function launchInSplit(
     size: size ?? null,
     tty: ownTtyPath() ?? callerTty().path,
   });
-  const deadline = Date.now() + 20_000;
+  // ssh auth prompts and bundle installs run inside the new pane first
+  const patience = argv.some((arg) => arg.startsWith("--ssh=")) ? 600_000 : 20_000;
+  const deadline = Date.now() + patience;
   while (Date.now() < deadline) {
     const fresh = (await instances()).find((record) => !before.has(recordKey(record)));
     if (fresh) {
@@ -381,7 +417,7 @@ async function launchInSplit(
     }
     await sleep(250);
   }
-  fail("browser did not register within 20s (is the split open?)");
+  fail(`browser did not register within ${Math.round(patience / 1000)}s (is the split open?)`);
 }
 
 let asked: Promise<TerminalCheck> | null = null;
@@ -436,6 +472,8 @@ const BROWSER_FLAGS = [
   "--open-tabs-in-popup-stack",
   "--allow-clipboard-read",
   "--partition=",
+  "--ssh=",
+  "--ssh-bundle=",
   "--preload=",
   "--main-script=",
   "--palette-key=",
@@ -456,6 +494,25 @@ function rejectUnknownFlags(args: string[]) {
   }
 }
 
+function takeSshFlags(args: string[]): void {
+  const ssh = takeFlag(args, "--ssh");
+  if (ssh !== undefined) args.push(`--ssh=${ssh}`);
+  const bundle = takeFlag(args, "--ssh-bundle");
+  if (bundle !== undefined) args.push(`--ssh-bundle=${bundle}`);
+  const at = args.findIndex((arg) => arg.startsWith("--ssh-bundle="));
+  if (at >= 0) {
+    args[at] = `--ssh-bundle=${path.resolve(args[at].slice("--ssh-bundle=".length))}`;
+  }
+  const target = args.find((arg) => arg.startsWith("--ssh="))?.slice("--ssh=".length);
+  if (at >= 0 && !target) fail("--ssh-bundle needs --ssh");
+  try {
+    if (target) parseSshTarget(target);
+    if (at >= 0) validateBundleDir(args[at].slice("--ssh-bundle=".length));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
 function requirePaneAccess(): void {
   const refusal = sandboxRefusal();
   if (refusal) fail(refusal);
@@ -466,6 +523,7 @@ async function openCommand(args: string[]) {
   const split = takeSplitFlag(args);
   const size = takeSizeFlag(args);
   if (size !== null && !split) fail("--size only applies to a split (--split <direction>)");
+  takeSshFlags(args);
   rejectUnknownFlags(args);
   const positionals = args.filter((arg) => !arg.startsWith("-"));
   if (positionals.length > 1) {

--- a/cli/src/ssh.ts
+++ b/cli/src/ssh.ts
@@ -1,0 +1,378 @@
+import { spawn, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { LOGS_DIR, ensureDataDir } from "pixel-store";
+
+export interface SshTunnel {
+  destination: string;
+  socksPort: number;
+  controlPath: string;
+  stop(): void;
+}
+
+export interface RemoteBundle {
+  url: string;
+  stop(): void;
+}
+
+export function parseSshTarget(target: string): { destination: string; sshPort: string | null } {
+  const match = /^([A-Za-z0-9._-]+@)?([A-Za-z0-9._-]+)(:(\d+))?$/.exec(target);
+  if (!match) {
+    throw new Error(
+      `invalid --ssh ${target} (user@host, host, user@host:port, or a shell alias for ssh)`,
+    );
+  }
+  return { destination: `${match[1] ?? ""}${match[2]}`, sshPort: match[4] ?? null };
+}
+
+interface ResolvedTarget {
+  destination: string;
+  hostArgs: string[];
+  aliasCommand: string | null;
+}
+
+export function resolveSshTarget(target: string): ResolvedTarget {
+  if (!target.includes("@") && !target.includes(":")) {
+    const alias = shellAlias(target);
+    if (alias) {
+      const parsed = parseSshCommand(alias);
+      if (parsed) return { ...parsed, aliasCommand: alias.join(" ") };
+    }
+  }
+  const { destination, sshPort } = parseSshTarget(target);
+  return { destination, hostArgs: sshPort ? ["-p", sshPort] : [], aliasCommand: null };
+}
+
+function shellAlias(name: string): string[] | null {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) return null;
+  const shell = process.env.SHELL ?? "/bin/sh";
+  const result = spawnSync(shell, ["-ic", `alias ${name}`], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 5000,
+  });
+  if (result.status !== 0 || !result.stdout) return null;
+  const line = result.stdout.trim().split("\n").pop() ?? "";
+  const eq = line.indexOf("=");
+  if (eq < 0) return null;
+  const tokens = unquote(line.slice(eq + 1).trim())
+    .split(/\s+/)
+    .filter(Boolean);
+  if (!/(^|\/)ssh$/.test(tokens[0] ?? "")) return null;
+  return tokens.slice(1);
+}
+
+function unquote(value: string): string {
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replaceAll(`'\\''`, "'");
+  }
+  if (value.startsWith('"') && value.endsWith('"')) return value.slice(1, -1);
+  return value.replaceAll("\\ ", " ");
+}
+
+const SSH_VALUE_FLAGS = new Set(
+  "-B -b -c -D -E -e -F -I -i -J -L -l -m -O -o -P -p -R -S -W -w".split(" "),
+);
+
+function parseSshCommand(tokens: string[]): { destination: string; hostArgs: string[] } | null {
+  const hostArgs: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token.startsWith("-")) {
+      hostArgs.push(token);
+      if (SSH_VALUE_FLAGS.has(token) && i + 1 < tokens.length) hostArgs.push(tokens[++i]);
+      continue;
+    }
+    return { destination: token, hostArgs };
+  }
+  return null;
+}
+
+export async function openSshTunnel(
+  target: string,
+  status: (line: string) => void,
+): Promise<SshTunnel> {
+  const { destination, hostArgs, aliasCommand } = resolveSshTarget(target);
+  if (aliasCommand) status(`${target} is an alias for ssh ${aliasCommand}`);
+  const controlPath = freshControlPath();
+  const socksPort = await freePort();
+  const args = [
+    "-f",
+    "-N",
+    "-M",
+    "-S",
+    controlPath,
+    "-D",
+    `127.0.0.1:${socksPort}`,
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "ServerAliveInterval=15",
+    "-o",
+    "ServerAliveCountMax=3",
+    ...hostArgs,
+    destination,
+  ];
+  status(`connecting to ${destination}`);
+  const code = await new Promise<number>((resolve, reject) => {
+    const child = spawn("ssh", args, { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (exitCode) => resolve(exitCode ?? 1));
+  });
+  if (code !== 0) throw new Error(`ssh to ${destination} failed`);
+  await waitForSocks(socksPort, destination);
+  status(`connected, pages will browse from ${destination}`);
+  return {
+    destination,
+    socksPort,
+    controlPath,
+    stop: () => {
+      try {
+        spawnSync("ssh", ["-S", controlPath, "-O", "exit", destination], {
+          stdio: "ignore",
+          timeout: 5000,
+        });
+      } catch {}
+    },
+  };
+}
+
+export function validateBundleDir(dir: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(dir);
+  } catch {
+    throw new Error(`--ssh-bundle ${dir} does not exist`);
+  }
+  if (!stat.isDirectory()) throw new Error(`--ssh-bundle ${dir} is not a directory`);
+  let start: fs.Stats;
+  try {
+    start = fs.statSync(path.join(dir, "start"));
+  } catch {
+    throw new Error(`--ssh-bundle ${dir} has no start script`);
+  }
+  if (!start.isFile() || !(start.mode & 0o111)) {
+    throw new Error(`--ssh-bundle ${dir}/start is not executable`);
+  }
+}
+
+const READY_TIMEOUT_MS = 120_000;
+
+export async function startBundle(
+  tunnel: SshTunnel,
+  dir: string,
+  status: (line: string) => void,
+): Promise<RemoteBundle> {
+  validateBundleDir(dir);
+  const name = bundleName(dir);
+  const remoteDir = `.terminal-browser/bundles/${name}-${bundleHash(dir).slice(0, 12)}`;
+  if (!installed(tunnel, remoteDir)) {
+    status(`installing ${name} on ${tunnel.destination}`);
+    upload(tunnel, dir, remoteDir);
+    setup(tunnel, remoteDir);
+  }
+  status(`starting ${name}`);
+  return launch(tunnel, name, remoteDir, status);
+}
+
+function bundleName(dir: string): string {
+  let name = path.basename(dir);
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(dir, "manifest.json"), "utf8"));
+    if (typeof manifest.name === "string" && manifest.name) name = manifest.name;
+  } catch {}
+  return name.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+function bundleHash(dir: string): string {
+  const hash = crypto.createHash("sha256");
+  const walk = (rel: string) => {
+    const entries = fs
+      .readdirSync(path.join(dir, rel), { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const childRel = path.join(rel, entry.name);
+      if (entry.isDirectory()) {
+        walk(childRel);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const stat = fs.statSync(path.join(dir, childRel));
+      hash.update(`${childRel}\0${stat.mode & 0o777}\0`);
+      hash.update(fs.readFileSync(path.join(dir, childRel)));
+      hash.update("\0");
+    }
+  };
+  walk("");
+  return hash.digest("hex");
+}
+
+function run(
+  tunnel: SshTunnel,
+  command: string,
+  options: { input?: Buffer; stdio?: "inherit" | "ignore"; timeout?: number } = {},
+): ReturnType<typeof spawnSync> {
+  return spawnSync("ssh", ["-S", tunnel.controlPath, tunnel.destination, command], {
+    input: options.input,
+    stdio: options.input ? undefined : options.stdio ?? "ignore",
+    timeout: options.timeout,
+    maxBuffer: 256 * 1024 * 1024,
+  });
+}
+
+function installed(tunnel: SshTunnel, remoteDir: string): boolean {
+  return run(tunnel, `test -f '${remoteDir}/.ready'`).status === 0;
+}
+
+function upload(tunnel: SshTunnel, dir: string, remoteDir: string): void {
+  const tar = spawnSync("tar", ["-cz", "-C", dir, "."], {
+    env: { ...process.env, COPYFILE_DISABLE: "1" },
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (tar.status !== 0 || !tar.stdout) throw new Error(`could not pack ${dir}`);
+  const result = run(tunnel, `mkdir -p '${remoteDir}' && tar -xz -C '${remoteDir}'`, {
+    input: tar.stdout,
+  });
+  if (result.status !== 0) {
+    throw new Error(`could not upload the bundle to ${tunnel.destination}`);
+  }
+}
+
+function setup(tunnel: SshTunnel, remoteDir: string): void {
+  const result = run(
+    tunnel,
+    `cd '${remoteDir}' && { [ ! -x ./setup ] || ./setup; } && touch .ready`,
+    { stdio: "inherit" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`the bundle's setup script failed on ${tunnel.destination}`);
+  }
+}
+
+function launch(
+  tunnel: SshTunnel,
+  name: string,
+  remoteDir: string,
+  status: (line: string) => void,
+): Promise<RemoteBundle> {
+  ensureDataDir();
+  fs.mkdirSync(LOGS_DIR, { recursive: true });
+  // meh i dont know if this is a great idea
+  const logPath = path.join(LOGS_DIR, `ssh-bundle-${name}.log`);
+  const log = fs.createWriteStream(logPath, { flags: "a" });
+  const tail: string[] = [];
+  const child = spawn(
+    "ssh",
+    [
+      "-tt",
+      "-S",
+      tunnel.controlPath,
+      tunnel.destination,
+      `cd '${remoteDir}' || exit 9; [ -x ./stop ] && ./stop >/dev/null 2>&1; exec ./start`,
+    ],
+    { stdio: ["ignore", "pipe", "ignore"] },
+  );
+  const stop = () => {
+    try {
+      run(tunnel, `cd '${remoteDir}' && [ -x ./stop ] && ./stop`, { timeout: 10_000 });
+    } catch {}
+    try {
+      child.kill();
+    } catch {}
+  };
+  return new Promise<RemoteBundle>((resolve, reject) => {
+    let buffer = "";
+    let done = false;
+    const finish = (result: RemoteBundle | Error) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      if (result instanceof Error) {
+        stop();
+        reject(result);
+      } else {
+        resolve(result);
+      }
+    };
+    const timer = setTimeout(() => {
+      finish(new Error(`${name} never printed READY <url> (output: ${logPath})`));
+    }, READY_TIMEOUT_MS);
+    const sawLine = (line: string) => {
+      tail.push(line);
+      if (tail.length > 20) tail.shift();
+      const ready = /^READY\s+(\S+)/.exec(line);
+      if (ready) {
+        status(`${name} is up at ${ready[1]}`);
+        finish({ url: ready[1], stop });
+      }
+    };
+    child.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      log.write(text);
+      buffer += text;
+      let newline = buffer.indexOf("\n");
+      while (newline !== -1) {
+        const line = buffer.slice(0, newline).replace(/\r$/, "");
+        buffer = buffer.slice(newline + 1);
+        newline = buffer.indexOf("\n");
+        sawLine(line);
+      }
+    });
+    child.once("error", (error) => finish(error));
+    child.once("close", (code) => {
+      if (buffer.trim()) sawLine(buffer.trim());
+      finish(
+        new Error(
+          `${name} exited with code ${code} before printing READY <url>\n${tail.join("\n")}`,
+        ),
+      );
+    });
+  });
+}
+
+function freshControlPath(): string {
+  const name = `${process.pid.toString(36)}-${Date.now().toString(36).slice(-5)}`;
+  const dir = path.join(os.tmpdir(), "tb-ssh");
+  const candidate = path.join(dir, name);
+  if (candidate.length <= 80) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    return candidate;
+  }
+  fs.mkdirSync("/tmp/tb-ssh", { recursive: true, mode: 0o700 });
+  return path.join("/tmp/tb-ssh", name);
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close(() => (port ? resolve(port) : reject(new Error("no free port"))));
+    });
+  });
+}
+
+function waitForSocks(port: number, destination: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, "127.0.0.1");
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`the ssh proxy for ${destination} never started listening`));
+    }, 5000);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      socket.end();
+      resolve();
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}

--- a/cli/src/ssh.ts
+++ b/cli/src/ssh.ts
@@ -308,10 +308,14 @@ function launch(
       tail.push(line);
       if (tail.length > 20) tail.shift();
       const ready = /^READY\s+(\S+)/.exec(line);
-      if (ready) {
-        status(`${name} is up at ${ready[1]}`);
-        finish({ url: ready[1], stop });
+      if (!ready) return;
+      const url = pageUrl(ready[1]);
+      if (!url) {
+        finish(new Error(`${name} printed READY ${ready[1]}, which is not an http(s) url`));
+        return;
       }
+      status(`${name} is up at ${url}`);
+      finish({ url, stop });
     };
     child.stdout.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
@@ -335,6 +339,15 @@ function launch(
       );
     });
   });
+}
+
+function pageUrl(token: string): string | null {
+  try {
+    const url = new URL(token);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
 }
 
 function freshControlPath(): string {

--- a/cli/src/ssh.ts
+++ b/cli/src/ssh.ts
@@ -5,8 +5,6 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
-import { LOGS_DIR, ensureDataDir } from "pixel-store";
-
 export interface SshTunnel {
   destination: string;
   socksPort: number;
@@ -262,11 +260,6 @@ function launch(
   remoteDir: string,
   status: (line: string) => void,
 ): Promise<RemoteBundle> {
-  ensureDataDir();
-  fs.mkdirSync(LOGS_DIR, { recursive: true });
-  // meh i dont know if this is a great idea
-  const logPath = path.join(LOGS_DIR, `ssh-bundle-${name}.log`);
-  const log = fs.createWriteStream(logPath, { flags: "a" });
   const tail: string[] = [];
   const child = spawn(
     "ssh",
@@ -302,7 +295,7 @@ function launch(
       }
     };
     const timer = setTimeout(() => {
-      finish(new Error(`${name} never printed READY <url> (output: ${logPath})`));
+      finish(new Error(`${name} never printed READY <url>\n${tail.join("\n")}`));
     }, READY_TIMEOUT_MS);
     const sawLine = (line: string) => {
       tail.push(line);
@@ -319,7 +312,6 @@ function launch(
     };
     child.stdout.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
-      log.write(text);
       buffer += text;
       let newline = buffer.indexOf("\n");
       while (newline !== -1) {

--- a/cli/src/ssh.ts
+++ b/cli/src/ssh.ts
@@ -162,14 +162,17 @@ export function validateBundleDir(dir: string): void {
 
 const READY_TIMEOUT_MS = 120_000;
 
+const REMOTE_BUNDLES_DIR = '${XDG_DATA_HOME:-$HOME/.local/share}/terminal-browser/bundles';
+
 export async function startBundle(
   tunnel: SshTunnel,
   dir: string,
   status: (line: string) => void,
+  remoteBase: string = REMOTE_BUNDLES_DIR,
 ): Promise<RemoteBundle> {
   validateBundleDir(dir);
   const name = bundleName(dir);
-  const remoteDir = `.terminal-browser/bundles/${name}-${bundleHash(dir).slice(0, 12)}`;
+  const remoteDir = `${remoteBase}/${name}-${bundleHash(dir).slice(0, 12)}`;
   if (!installed(tunnel, remoteDir)) {
     status(`installing ${name} on ${tunnel.destination}`);
     upload(tunnel, dir, remoteDir);
@@ -225,7 +228,7 @@ function run(
 }
 
 function installed(tunnel: SshTunnel, remoteDir: string): boolean {
-  return run(tunnel, `test -f '${remoteDir}/.ready'`).status === 0;
+  return run(tunnel, `test -f "${remoteDir}/.ready"`).status === 0;
 }
 
 function upload(tunnel: SshTunnel, dir: string, remoteDir: string): void {
@@ -234,7 +237,7 @@ function upload(tunnel: SshTunnel, dir: string, remoteDir: string): void {
     maxBuffer: 256 * 1024 * 1024,
   });
   if (tar.status !== 0 || !tar.stdout) throw new Error(`could not pack ${dir}`);
-  const result = run(tunnel, `mkdir -p '${remoteDir}' && tar -xz -C '${remoteDir}'`, {
+  const result = run(tunnel, `mkdir -p "${remoteDir}" && tar -xz -C "${remoteDir}"`, {
     input: tar.stdout,
   });
   if (result.status !== 0) {
@@ -245,7 +248,7 @@ function upload(tunnel: SshTunnel, dir: string, remoteDir: string): void {
 function setup(tunnel: SshTunnel, remoteDir: string): void {
   const result = run(
     tunnel,
-    `cd '${remoteDir}' && { [ ! -x ./setup ] || ./setup; } && touch .ready`,
+    `cd "${remoteDir}" && { [ ! -x ./setup ] || ./setup; } && touch .ready`,
     { stdio: "inherit" },
   );
   if (result.status !== 0) {
@@ -272,13 +275,13 @@ function launch(
       "-S",
       tunnel.controlPath,
       tunnel.destination,
-      `cd '${remoteDir}' || exit 9; [ -x ./stop ] && ./stop >/dev/null 2>&1; exec ./start`,
+      `cd "${remoteDir}" || exit 9; [ -x ./stop ] && ./stop >/dev/null 2>&1; exec ./start`,
     ],
     { stdio: ["ignore", "pipe", "ignore"] },
   );
   const stop = () => {
     try {
-      run(tunnel, `cd '${remoteDir}' && [ -x ./stop ] && ./stop`, { timeout: 10_000 });
+      run(tunnel, `cd "${remoteDir}" && [ -x ./stop ] && ./stop`, { timeout: 10_000 });
     } catch {}
     try {
       child.kill();


### PR DESCRIPTION
This PR introduces a new feature in terminal-browser that allows a user to set a remote server to proxy browser network requests via [SOCKS](https://en.wikipedia.org/wiki/SOCKS).

The `ssh` cli allows us to run a local SOCKS server that chromium will communicate to anytime it wants to make a network request. The SOCKS server translates the chromium messages into instructions for an [ssh server](https://www.ssh.com/academy/ssh/sshd) to make the network requests. The result is then sent back over the ssh connection to the SOCKS server, and then finally piped back to chriomium.

This allows terminal-browser to run using local hardware, but access websites that are local to a remote machine. Practically, this means you can load a localhost url from terminal-browser on the remote machine.

We also include a new option `--ssh-bundle`. This is built specifically for applications that want to run on remote machines , and need to run some code on that machine to serve a website and interact with the machine. For example, [terminal-code](https://github.com/zenbu-labs/terminal-code) would want to install the [code server](https://github.com/coder/code-server) bundle, start the server, and then load the served website inside the users local terminal browser. `--ssh-bundle` accepts a path that will get packaged into a tarball, the tarball bytes are sent over the ssh connection and get untarred. The written bundle is expected to be of the format:
```
my-bundle/
  start            
  setup          optional
  stop          optional
  manifest.json    optional, { "name": "..." } 
```
After install `setup` is ran, so the program can handle configuring itself. After the bundle is installed and setup, `start` is executed which is expected to print to stdout `READY <url>`. This URL is interpreted by the local terminal-browser and loaded. `stop` is called when the local terminal-browser is quit.

`--ssh-bundle-dir` can be specified to configure where the `ssh-bundle` gets created via the ssh server.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->