### PR TITLE
Made browser partitions stable

### DIFF
--- a/browser/src/main.tsx
+++ b/browser/src/main.tsx
@@ -22,7 +22,6 @@ try {
 app.commandLine.appendSwitch("enable-logging", "file");
 app.commandLine.appendSwitch("log-file", path.join(LOGS_DIR, "chromium.log"));
 app.setName("terminal-browser");
-claimProfile();
 
 
 function freePort(): Promise<number> {
@@ -41,6 +40,7 @@ function freePort(): Promise<number> {
 
 
 void (async () => {
+  await claimProfile();
   const cdpPort = await freePort().catch(() => null);
   if (cdpPort != null) app.commandLine.appendSwitch("remote-debugging-port", String(cdpPort));
   await app.whenReady();

--- a/browser/src/profile.ts
+++ b/browser/src/profile.ts
@@ -5,9 +5,13 @@ import path from "node:path";
 import { app } from "electron";
 import { APP_DIR_NAME } from "pixel-store";
 
-// er i don't think this is necessary anymore given our daemon but i guess it doesn't hurt to be explicit 
-export function claimProfile() {
+// the daemon keeps the base profile dir across restarts so --partition storage
+// never moves; the lock claim prevents two daemons sharing a dir
+const DAEMON_LOCK_WAIT_MS = 5_000;
+
+export async function claimProfile(): Promise<void> {
   const appData = process.env.TERMINAL_BROWSER_APPDATA ?? app.getPath("appData");
+  await waitForFreeLock(path.join(appData, APP_DIR_NAME, "terminal-browser.lock"));
   for (let i = 0; i < 32; i++) {
     const dir = path.join(appData, i === 0 ? APP_DIR_NAME : `${APP_DIR_NAME}-${i + 1}`);
     const lock = path.join(dir, "terminal-browser.lock");
@@ -29,10 +33,26 @@ export function claimProfile() {
       return;
     } catch {}
   }
-  app.setPath("userData", fs.mkdtempSync(path.join(os.tmpdir(), "terminal-browser-")));
+  app.setPath("userData", fs.mkdtempSync(path.join(os.tmpdir(), APP_DIR_NAME)));
 }
 
-function alive(pid: number) {
+// a previous daemon may still be releasing the dir when we start; if it frees
+// up soon we keep the base dir instead of drifting to a numbered one
+async function waitForFreeLock(lock: string): Promise<void> {
+  const deadline = Date.now() + DAEMON_LOCK_WAIT_MS;
+  while (Date.now() < deadline) {
+    let holder: number;
+    try {
+      holder = Number(fs.readFileSync(lock, "utf8"));
+    } catch {
+      return;
+    }
+    if (!holder || !alive(holder)) return;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+function alive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -13,6 +13,7 @@ import type { Pane, Terminal } from "pixel-terminals";
 import {
   browserSession,
   configureBrowserSession,
+  persistentPartition,
   routeThroughSocksProxy,
 } from "../page/browser-session";
 import type { DownloadProgress } from "../page/browser-session";
@@ -194,7 +195,6 @@ class Session {
     tabsAsPopups: boolean;
   };
   private readonly appIdentity: TabApp | null;
-  private readonly appPartitions: string[] = [];
   private embedderIpc = false;
   private wasBare = false;
   private paletteApps: RegisteredApp[] = [];
@@ -292,9 +292,10 @@ class Session {
     const sshTarget = flagValue(this.argv, "--ssh");
     const socksPort = Number(flagValue(this.argv, "--socks-port"));
     this.socksPort = Number.isInteger(socksPort) && socksPort > 0 ? socksPort : null;
-    this.partition =
+    const rawPartition =
       flagValue(this.argv, "--partition") ??
       (sshTarget ? `ssh-${sshTarget.replace(/[^A-Za-z0-9@._-]/g, "-")}` : null);
+    this.partition = rawPartition ? persistentPartition(rawPartition) : null;
     this.preload = flagValue(this.argv, "--preload");
     this.mainScript = flagValue(this.argv, "--main-script");
     this.fallbackState = initialBrowserState(this.initialUrl());
@@ -560,14 +561,6 @@ class Session {
     try {
       this.root?.setPointerShape("text");
     } catch { }
-    try {
-      browserSession(this.partition).flushStorageData();
-    } catch { }
-    for (const partition of this.appPartitions) {
-      try {
-        browserSession(partition).flushStorageData();
-      } catch { }
-    }
     this.registry?.dispose();
     this.registry = null;
     this.tabs.stopAll();
@@ -659,7 +652,6 @@ class Session {
     }
     if (app.mainScript) createRequire(app.mainScript)(app.mainScript);
     this.ensureEmbedderIpc();
-    if (!this.appPartitions.includes(partition)) this.appPartitions.push(partition);
     const tab = this.tabs.create(spec.url ? normalizeUrl(spec.url) : DEFAULT_URL, true, {
       app: { name: app.name ?? null, id },
       partition,

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -48,12 +48,14 @@ Options:
   --app-name=<name>     The name of the application
   --app-id=<id>         The identifier of the application
   --no-merge            Do not open the terminal-browser instance as a tab in a neighbor terminal-browser
-
+  --partition=<name>    Isolated storage profile. Cookies and site data for
+                        the partition are kept on disk between runs
 
 Examples:
   terminal-browser open localhost:3000
   terminal-browser open ./report.html --split right
   terminal-browser open github.com/zenbu-labs --split down --size 0.4
+  terminal-browser open --partition=work github.com
   terminal-browser open --ssh dev@build-box localhost:8080
 `,
   },

--- a/skill/terminal-browser/SKILL.template.md
+++ b/skill/terminal-browser/SKILL.template.md
@@ -9,6 +9,10 @@ new pane beside the human, which is how you show a page next to the
 conversation. A path to a local html file works the same as a url, so writing a
 page and opening it is a way to show something you built.
 
+Pass `--partition=<name>` to give a browser its own storage profile — cookies
+and site data are kept on disk between runs, so a logged-in session survives
+restarts.
+
 `terminal-browser ls` shows the browsers and tabs in this terminal tab, with the
 tab ids the other commands take.
 


### PR DESCRIPTION
# Keep `--partition` storage stable across daemon restarts

`--partition` storage lives under the daemon's userData directory. At startup the daemon claims the first free one: the base dir, then it increments to `-2`, `-3`, and so on. On restart, if the previous daemon was still shutting down, its lock file still exists. So the base dir can look like it is taken and the new daemon silently claims a new dir. 

And likelihood of this to happen is relatively high: the daemon idle-exits 15s after the last session closes, and teardown takes a moment, so the next `terminal-browser open` can start while the old daemon is still exiting.

## Fix

Before claiming a directory, the daemon now waits briefly (up to 5s) for the base dir's previous holder to exit, so an overlapping restart reclaims the
same directory instead of drifting to a numbered one. 

In addition, the `--partition` flag is normalized to its `persist:` form once, where it is parsed, so all consumers share the canonical session name,
and the redundant `flushStorageData()` on shutdown is dropped, because Chromium commits DOM storage on its own.

The `--partition` flag is now documented in the CLI help and the skill template.

## Verification

Here is a minimal test that reproduces the issue:

```bash
#!/bin/bash
set -u
ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
ELECTRON="$ROOT/browser/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron"
MAIN="$ROOT/browser/dist/main.js"

E="${TB_TEST_DIR:-$(mktemp -d)}"
mkdir -p "$E/appdata" "$E/rt" "$E/state" "$E/data"
export TERMINAL_BROWSER_APPDATA="$E/appdata" XDG_RUNTIME_DIR="$E/rt" XDG_STATE_HOME="$E/state" XDG_DATA_HOME="$E/data"
APP_DIR_NAME="$(cd "$ROOT/browser" && node -p 'require("pixel-store").APP_DIR_NAME')"
BASE="$E/appdata/$APP_DIR_NAME"

# daemon A claims the base dir, then exits mid-shutdown: its lock still names
# a process that is alive but exits ~4s later
"$ELECTRON" "$MAIN" --daemon >/dev/null 2>&1 &
A=$!
for i in $(seq 100); do [ "$(cat "$BASE/terminal-browser.lock" 2>/dev/null)" = "$A" ] && break; sleep 0.1; done
kill -TERM $A; wait $A 2>/dev/null
sleep 4 & echo $! > "$BASE/terminal-browser.lock"

# daemon B restarts into the overlap window
"$ELECTRON" "$MAIN" --daemon >/dev/null 2>&1 &
B=$!
ok=""
for i in $(seq 150); do
  [ "$(cat "$BASE/terminal-browser.lock" 2>/dev/null)" = "$B" ] && ok=1 && break
  [ -d "$BASE-2" ] && break
  sleep 0.2
done
kill -TERM $B 2>/dev/null

if [ -n "$ok" ] && [ ! -d "$BASE-2" ]; then
  echo "PASS: same storage dir after overlapping restart"
else
  echo "FAIL: storage moved to $(cd "$E/appdata" && ls)"
fi
```

