### PR TITLE
fix: restore the --right-click fallback for herdr stable

### DIFF
--- a/terminals/src/terminals/herdr.ts
+++ b/terminals/src/terminals/herdr.ts
@@ -42,7 +42,13 @@ export const herdr: Detect = (env, run) => {
   const herdr = (args: string[]) => run(bin, args);
 
   async function splitPane(args: string[]): Promise<HerdrPaneSplitResult> {
-    return JSON.parse(await herdr(["pane", "split", ...args, "--right-click", "pane"]));
+    try {
+      return JSON.parse(await herdr(["pane", "split", ...args, "--right-click", "pane"]));
+    } catch (error) {
+      const stderr = error && typeof error === "object" && "stderr" in error ? String(error.stderr ?? "") : "";
+      if (!stderr.includes("--right-click")) throw error;
+      return JSON.parse(await herdr(["pane", "split", ...args]));
+    }
   }
 
   async function prepare(): Promise<void> {


### PR DESCRIPTION
Fixes #40.

herdr only grew `pane split --right-click` on the preview channel, so on herdr 0.8.0 stable every split from terminal-browser fails with `unknown option: --right-click`. This restores the fallback removed in 01debb5: try with `--right-click pane`, and if herdr rejects the flag, retry without it.

Verified: `npm run typecheck` and `npm test` in `terminals/` pass.