### PR TITLE
fix: bound Herdr fallback frame load

### DIFF
--- a/engine/crates/pixel-core/src/engine/mod.rs
+++ b/engine/crates/pixel-core/src/engine/mod.rs
@@ -322,7 +322,7 @@ pub struct Engine {
     last_color_request: Option<Instant>,
     last_step: Instant,
     last_frame: Instant,
-    last_frame_bytes: usize,
+    last_frame_budget_bytes: Option<usize>,
     frame_deferred: bool,
     frame_budget_bytes_per_sec: f32,
     pub stats: FrameStats,
@@ -421,7 +421,7 @@ impl Engine {
             last_color_request: None,
             last_step: Instant::now(),
             last_frame: Instant::now(),
-            last_frame_bytes: 0,
+            last_frame_budget_bytes: None,
             frame_deferred: false,
             frame_budget_bytes_per_sec: frame_budget_bytes_per_sec(),
             stats: FrameStats::default(),
@@ -944,14 +944,7 @@ impl Engine {
     }
 
     fn frame_debt(&self) -> Duration {
-        if !self.term.frames_are_inline() {
-            return Duration::ZERO;
-        }
-        let budget = self.frame_budget_bytes_per_sec;
-        if budget <= 0.0 {
-            return Duration::ZERO;
-        }
-        Duration::from_secs_f32((self.last_frame_bytes as f32 / budget).min(0.2))
+        frame_debt(self.last_frame_budget_bytes, self.frame_budget_bytes_per_sec)
     }
 
     fn draws_something(&self) -> bool {
@@ -1038,7 +1031,9 @@ impl Engine {
             self.compose(&painted);
             let bytes = crate::profiler::span("draw", || self.term.draw(&self.comp.frame))?;
             crate::profiler::count("bytes", bytes as u64);
-            self.last_frame_bytes = bytes;
+            self.last_frame_budget_bytes = self
+                .term
+                .frame_budget_bytes(bytes, self.comp.frame.pixels.len());
 
             let gap = start.duration_since(self.last_frame).as_secs_f32();
             self.last_frame = start;
@@ -1075,6 +1070,16 @@ impl Engine {
 }
 
 const DEFAULT_FRAME_BUDGET_MB_PER_SEC: f32 = 3.0;
+
+fn frame_debt(bytes: Option<usize>, budget: f32) -> Duration {
+    let Some(bytes) = bytes else {
+        return Duration::ZERO;
+    };
+    if budget <= 0.0 {
+        return Duration::ZERO;
+    }
+    Duration::from_secs_f32(bytes as f32 / budget)
+}
 
 fn frame_budget_bytes_per_sec() -> f32 {
     let configured = std::env::var("TERMINAL_BROWSER_FRAME_BUDGET_MBPS")
@@ -1127,5 +1132,17 @@ mod tests {
             height_px: 800,
         };
         assert_eq!(window_from(&ws, (11, 21)), (1045, 798));
+    }
+
+    #[test]
+    fn frame_debt_enforces_the_full_byte_budget() {
+        let bytes = Some(5_000_000);
+        assert_eq!(
+            frame_debt(bytes, 3_000_000.0),
+            Duration::from_secs_f32(5.0 / 3.0)
+        );
+        assert!(frame_debt(bytes, 3_000_000.0) > Duration::from_millis(200));
+        assert_eq!(frame_debt(None, 3_000_000.0), Duration::ZERO);
+        assert_eq!(frame_debt(bytes, 0.0), Duration::ZERO);
     }
 }

--- a/engine/crates/pixel-core/src/kitty.rs
+++ b/engine/crates/pixel-core/src/kitty.rs
@@ -22,6 +22,19 @@ impl Placement {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TransmitOptions {
+    pub placement: Placement,
+    pub wrapper: Wrapper,
+    pub wait_for_response: bool,
+}
+
+impl TransmitOptions {
+    fn quiet(self) -> u8 {
+        if self.wait_for_response { 0 } else { 2 }
+    }
+}
+
 fn emit(out: &mut Vec<u8>, seq: &[u8], wrapper: Wrapper) {
     out.extend_from_slice(&wrapper.wrap(seq));
 }
@@ -65,22 +78,32 @@ pub(crate) fn kitty_transmit_named(
     height: u32,
     name: &str,
     medium: Medium,
-    placement: Placement,
-    wrapper: Wrapper,
+    options: TransmitOptions,
 ) -> Vec<u8> {
     let payload = BASE64.encode(name);
-    let keys = placement.keys();
+    let keys = options.placement.keys();
     let t = medium.key();
+    let quiet = options.quiet();
     let seq = format!(
-        "\x1b_Ga=T,f=32,s={width},v={height},t={t},i={image_id},{keys},q=2;{payload}\x1b\\"
+        "\x1b_Ga=T,f=32,s={width},v={height},t={t},i={image_id},{keys},q={quiet};{payload}\x1b\\"
     );
     let mut out = Vec::new();
-    emit(&mut out, seq.as_bytes(), wrapper);
+    emit(&mut out, seq.as_bytes(), options.wrapper);
     out
 }
 
 pub fn kitty_transmit(image_id: u32, width: u32, height: u32, rgba: &[u8]) -> Vec<u8> {
-    kitty_transmit_placed(image_id, width, height, rgba, Placement::Cursor, Wrapper::None)
+    kitty_transmit_placed(
+        image_id,
+        width,
+        height,
+        rgba,
+        TransmitOptions {
+            placement: Placement::Cursor,
+            wrapper: Wrapper::None,
+            wait_for_response: false,
+        },
+    )
 }
 
 pub(crate) fn kitty_transmit_placed(
@@ -88,8 +111,7 @@ pub(crate) fn kitty_transmit_placed(
     width: u32,
     height: u32,
     rgba: &[u8],
-    placement: Placement,
-    wrapper: Wrapper,
+    options: TransmitOptions,
 ) -> Vec<u8> {
     assert_eq!(rgba.len(), (width * height * 4) as usize);
     let compressed = crate::profiler::span("kitty.compress", || {
@@ -106,9 +128,10 @@ pub(crate) fn kitty_transmit_placed(
         seq.clear();
         seq.extend_from_slice(b"\x1b_G");
         if i == 0 {
-            let keys = placement.keys();
+            let keys = options.placement.keys();
+            let quiet = options.quiet();
             seq.extend_from_slice(
-                format!("a=T,f=32,o=z,s={width},v={height},t=d,i={image_id},{keys},q=2,m={more}")
+                format!("a=T,f=32,o=z,s={width},v={height},t=d,i={image_id},{keys},q={quiet},m={more}")
                     .as_bytes(),
             );
         } else {
@@ -117,7 +140,7 @@ pub(crate) fn kitty_transmit_placed(
         seq.push(b';');
         seq.extend_from_slice(chunk);
         seq.extend_from_slice(b"\x1b\\");
-        emit(&mut out, &seq, wrapper);
+        emit(&mut out, &seq, options.wrapper);
     }
     out
 }
@@ -234,6 +257,36 @@ mod tests {
     }
 
     #[test]
+    fn acknowledged_transfers_request_a_response() {
+        let named = kitty_transmit_named(
+            9,
+            1,
+            1,
+            "/tmp/frame",
+            Medium::File,
+            TransmitOptions {
+                placement: Placement::Cursor,
+                wrapper: Wrapper::None,
+                wait_for_response: true,
+            },
+        );
+        assert!(String::from_utf8(named).unwrap().contains("i=9,p=1,C=1,q=0;"));
+
+        let inline = kitty_transmit_placed(
+            9,
+            1,
+            1,
+            &[0, 0, 0, 255],
+            TransmitOptions {
+                placement: Placement::Cursor,
+                wrapper: Wrapper::None,
+                wait_for_response: true,
+            },
+        );
+        assert!(String::from_utf8(inline).unwrap().contains("i=9,p=1,C=1,q=0,m=0;"));
+    }
+
+    #[test]
     fn virtual_placement_transmit_wraps_every_chunk_for_tmux() {
         let mut seed = 0x9e3779b9u32;
         let pixels: Vec<u8> = (0..64 * 64 * 4)
@@ -247,8 +300,11 @@ mod tests {
             64,
             64,
             &pixels,
-            Placement::Cells { cols: 8, rows: 4 },
-            Wrapper::Tmux,
+            TransmitOptions {
+                placement: Placement::Cells { cols: 8, rows: 4 },
+                wrapper: Wrapper::Tmux,
+                wait_for_response: false,
+            },
         );
         let text = String::from_utf8_lossy(&out);
         assert!(text.starts_with("\x1bPtmux;\x1b\x1b_Ga=T,"));

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 use rustix::termios::{self, OptionalActions, Termios};
 
 use crate::canvas::Canvas;
+use crate::kitty::{Placement, TransmitOptions};
 use crate::wrapper::Wrapper;
-use crate::kitty::Placement;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
@@ -585,6 +585,7 @@ impl Terminal {
                 }
             }
         }
+        let acknowledged = self.herdr_target.is_some() && self.herdr.is_none();
         let shrank = self
             .last_frame_size
             .is_some_and(|(w, h)| canvas.width < w || canvas.height < h);
@@ -610,6 +611,11 @@ impl Terminal {
             frame.extend_from_slice(b"\x1b[H");
             Placement::Cursor
         };
+        let transmit = TransmitOptions {
+            placement,
+            wrapper: self.wrapper,
+            wait_for_response: acknowledged,
+        };
         /*
          we eventualy need to be more principled about
          being generic over graphcis protocols to support
@@ -630,8 +636,7 @@ impl Terminal {
                 canvas.height,
                 &name,
                 medium,
-                placement,
-                self.wrapper,
+                transmit,
             ));
         } else {
             frame.extend_from_slice(&crate::kitty::kitty_transmit_placed(
@@ -639,8 +644,7 @@ impl Terminal {
                 canvas.width,
                 canvas.height,
                 &canvas.pixels,
-                placement,
-                self.wrapper,
+                transmit,
             ));
         }
         if let Placement::Cells { cols, rows } = placement
@@ -654,6 +658,18 @@ impl Terminal {
             self.io.out().write_all(&frame)?;
             self.io.out().flush()
         })?;
+        if acknowledged {
+            match self.wait_for_graphics_ack()? {
+                Some(true) => {}
+                Some(false) => return Err(io::Error::other("herdr rejected a fallback frame")),
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "herdr did not acknowledge a fallback frame",
+                    ));
+                }
+            }
+        }
         Ok(frame.len())
     }
 
@@ -858,8 +874,13 @@ impl Terminal {
         self.mouse_pixels
     }
 
-    pub fn frames_are_inline(&self) -> bool {
-        self.transport == FrameTransport::Inline
+    pub fn frame_budget_bytes(&self, written: usize, pixels: usize) -> Option<usize> {
+        budgeted_frame_bytes(
+            self.transport,
+            self.herdr_target.is_some() && self.herdr.is_none(),
+            written,
+            pixels,
+        )
     }
 
     pub fn forget_cell_size(&mut self) {
@@ -1023,6 +1044,37 @@ impl Terminal {
         }
     }
 
+    fn wait_for_graphics_ack(&mut self) -> io::Result<Option<bool>> {
+        let deadline = Instant::now() + HERDR_FALLBACK_ACK_TIMEOUT;
+        let needle = format!("Gi={}", self.image_id);
+        let mut buf = Vec::new();
+        loop {
+            if let Some(reply) = take_graphics_reply(&mut buf, needle.as_bytes()) {
+                self.pending.extend_from_slice(&buf);
+                return Ok(Some(reply));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                self.pending.extend_from_slice(&buf);
+                return Ok(None);
+            }
+            if !self.wait_for_input(Some(remaining))? {
+                continue;
+            }
+            let mut chunk = [0u8; 64];
+            let n = match rustix::io::read(self.io.read_fd(), &mut chunk) {
+                Ok(n) => n,
+                Err(rustix::io::Errno::INTR) => continue,
+                Err(e) => return Err(e.into()),
+            };
+            if n == 0 {
+                self.pending.extend_from_slice(&buf);
+                return Ok(None);
+            }
+            buf.extend_from_slice(&chunk[..n]);
+        }
+    }
+
     pub fn set_pointer_shape(&mut self, shape: &str) -> io::Result<()> {
         if !shape.bytes().all(|b| b.is_ascii_lowercase() || b == b'-') {
             return Ok(());
@@ -1113,12 +1165,28 @@ const FRAME_SLOTS: u64 = 8;
 
 const HERDR_RETRY_MIN: Duration = Duration::from_secs(1);
 const HERDR_RETRY_MAX: Duration = Duration::from_secs(10);
+const HERDR_FALLBACK_ACK_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FrameTransport {
     File,
     Shared,
     Inline,
+}
+
+fn budgeted_frame_bytes(
+    transport: FrameTransport,
+    herdr_fallback: bool,
+    written: usize,
+    pixels: usize,
+) -> Option<usize> {
+    if herdr_fallback {
+        Some(pixels)
+    } else if transport == FrameTransport::Inline {
+        Some(written)
+    } else {
+        None
+    }
 }
 
 static NEXT_TERMINAL_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -1143,6 +1211,42 @@ fn parse_probe_reply(buf: &[u8], needle: &[u8]) -> Option<bool> {
         return None;
     }
     Some(rest.starts_with(b"OK"))
+}
+
+fn take_graphics_reply(buf: &mut Vec<u8>, needle: &[u8]) -> Option<bool> {
+    let envelopes: &[(&[u8], &[u8])] = &[
+        (b"\x1b_", b"\x1b\\"),
+        (b"\x1b[27;3;95~", b"\x1b[27;3;92~"),
+        (b"\x1b[95;3u", b"\x1b[92;3u"),
+    ];
+    for found in buf
+        .windows(needle.len())
+        .enumerate()
+        .filter_map(|(at, window)| (window == needle).then_some(at))
+    {
+        let Some((opener, terminator)) = envelopes
+            .iter()
+            .copied()
+            .find(|(opener, _)| buf[..found].ends_with(opener))
+        else {
+            continue;
+        };
+        let start = found - opener.len();
+        let params = found + needle.len();
+        if !matches!(buf.get(params), Some(b';' | b',')) {
+            continue;
+        }
+        let terminator_at = buf[params..]
+            .windows(terminator.len())
+            .position(|window| window == terminator)?;
+        let end = params + terminator_at + terminator.len();
+        let reply = &buf[params..params + terminator_at];
+        let separator = reply.iter().position(|byte| *byte == b';')?;
+        let accepted = reply[separator + 1..].starts_with(b"OK");
+        buf.drain(start..end);
+        return Some(accepted);
+    }
+    None
 }
 
 #[allow(unsafe_code)]
@@ -1912,6 +2016,75 @@ mod tests {
     use super::*;
 
     #[test]
+    fn herdr_fallback_budgets_full_pixels_for_every_terminal_transport() {
+        for transport in [
+            FrameTransport::File,
+            FrameTransport::Shared,
+            FrameTransport::Inline,
+        ] {
+            assert_eq!(
+                budgeted_frame_bytes(transport, true, 120, 2_400_000),
+                Some(2_400_000)
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_terminal_transports_keep_the_existing_budget_policy() {
+        assert_eq!(
+            budgeted_frame_bytes(FrameTransport::File, false, 120, 2_400_000),
+            None
+        );
+        assert_eq!(
+            budgeted_frame_bytes(FrameTransport::Shared, false, 120, 2_400_000),
+            None
+        );
+        assert_eq!(
+            budgeted_frame_bytes(FrameTransport::Inline, false, 3_200_000, 2_400_000),
+            Some(3_200_000)
+        );
+    }
+
+    #[test]
+    fn graphics_reply_is_removed_without_losing_neighboring_input() {
+        let mut buf = b"before\x1b_Gi=1;OK\x1b\\after".to_vec();
+        assert_eq!(take_graphics_reply(&mut buf, b"Gi=1"), Some(true));
+        assert_eq!(buf, b"beforeafter");
+
+        let mut rejected = b"\x1b_Gi=1;ENOENT:not found\x1b\\".to_vec();
+        assert_eq!(take_graphics_reply(&mut rejected, b"Gi=1"), Some(false));
+        assert!(rejected.is_empty());
+
+        let mut placed = b"before\x1b_Gi=1,p=1;OK\x1b\\after".to_vec();
+        assert_eq!(take_graphics_reply(&mut placed, b"Gi=1"), Some(true));
+        assert_eq!(placed, b"beforeafter");
+
+        let mut partial = b"\x1b_Gi=1;O".to_vec();
+        assert_eq!(take_graphics_reply(&mut partial, b"Gi=1"), None);
+        assert_eq!(partial, b"\x1b_Gi=1;O");
+
+        let mut relayed = b"before\x1b[27;3;95~Gi=1;OK\x1b[27;3;92~after".to_vec();
+        assert_eq!(take_graphics_reply(&mut relayed, b"Gi=1"), Some(true));
+        assert_eq!(relayed, b"beforeafter");
+
+        let mut csi_u = b"before\x1b[95;3uGi=1;OK\x1b[92;3uafter".to_vec();
+        assert_eq!(take_graphics_reply(&mut csi_u, b"Gi=1"), Some(true));
+        assert_eq!(csi_u, b"beforeafter");
+
+        let mut text = b"Gi=1;OK before\x1b_Gi=1;OK\x1b\\after".to_vec();
+        assert_eq!(take_graphics_reply(&mut text, b"Gi=1"), Some(true));
+        assert_eq!(text, b"Gi=1;OK beforeafter");
+
+        let mut text = b"Gi=1;OK".to_vec();
+        assert_eq!(take_graphics_reply(&mut text, b"Gi=1"), None);
+        assert_eq!(text, b"Gi=1;OK");
+
+        let mut wrong_image = b"\x1b_Gi=10,p=1;OK\x1b\\".to_vec();
+        assert_eq!(take_graphics_reply(&mut wrong_image, b"Gi=1"), None);
+        assert_eq!(wrong_image, b"\x1b_Gi=10,p=1;OK\x1b\\");
+    }
+
+    #[test]
     fn parses_probe_replies() {
         let parse = |buf: &[u8]| parse_probe_reply(buf, b"Gi=299;");
         assert_eq!(parse(b"\x1b_Gi=299;OK\x1b\\"), Some(true));
@@ -2613,5 +2786,66 @@ mod tty_tests {
         });
         let got = term.poll_event(None).unwrap();
         assert!(got.is_none(), "a wake carries no terminal event: {got:?}");
+    }
+
+    #[test]
+    fn herdr_fallback_waits_for_a_tmux_csi_u_reply() {
+        use std::io::{Read as _, Write as _};
+        use std::os::fd::AsFd as _;
+
+        let (master, _slave, path) = open_pty();
+        let env = SessionEnv::of_session(Default::default());
+        let mut term = Terminal::open(&path, Wrapper::Tmux, env).unwrap();
+        term.herdr_target = Some(crate::herdr::HerdrTarget {
+            pane: "test".into(),
+            socket: "test".into(),
+        });
+        term.transport = FrameTransport::File;
+
+        let image_id = term.image_id;
+        let mut peer = master.try_clone().unwrap();
+        let responder = std::thread::spawn(move || {
+            let marker = format!("i={image_id},U=1,c=1,r=1,q=0;");
+            let deadline = Instant::now() + Duration::from_secs(1);
+            let mut output = Vec::new();
+            loop {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                assert!(!remaining.is_zero(), "frame request was not written");
+                let timeout = rustix::event::Timespec::try_from(remaining).unwrap();
+                let peer_fd = peer.as_fd();
+                let mut fds = [rustix::event::PollFd::new(
+                    &peer_fd,
+                    rustix::event::PollFlags::IN,
+                )];
+                assert!(
+                    rustix::event::poll(&mut fds, Some(&timeout)).unwrap() > 0,
+                    "frame request was not written"
+                );
+                let mut chunk = [0u8; 4096];
+                let n = peer.read(&mut chunk).unwrap();
+                assert!(n > 0, "terminal closed before writing a frame");
+                output.extend_from_slice(&chunk[..n]);
+                if output
+                    .windows(marker.len())
+                    .any(|window| window == marker.as_bytes())
+                {
+                    std::thread::sleep(Duration::from_millis(20));
+                    write!(peer, "x\x1b[95;3uGi={image_id},p=1;OK\x1b[92;3uy").unwrap();
+                    return output;
+                }
+            }
+        });
+
+        let started = Instant::now();
+        term.draw(&Canvas::new(1, 1)).unwrap();
+        assert!(started.elapsed() >= Duration::from_millis(20));
+        responder.join().unwrap();
+
+        let first = term.poll_event(Some(Duration::ZERO)).unwrap();
+        assert!(matches!(&first, Some(Event::Key(key)) if key.key == Key::Char('x')));
+        let second = term.poll_event(Some(Duration::ZERO)).unwrap();
+        assert!(matches!(&second, Some(Event::Key(key)) if key.key == Key::Char('y')));
+
+        let _drain = drain(&master);
     }
 }


### PR DESCRIPTION
## Summary

- request and wait for Kitty acknowledgements when Herdr falls back to terminal graphics
- pace fallback frames by their full raw RGBA size using the existing 3 MB/s byte budget
- coalesce intermediate paints while the previous frame's byte debt remains
- preserve ordinary keyboard input while parsing Kitty replies, including tmux and CSI-u envelopes

## Why

When Herdr does not offer `file_frame_transport=direct-kitty`—for example, after a remote Mosh client attaches—terminal-browser falls back to sending Kitty frames through the pane. The previous fallback capped frame debt at 200 ms and could budget the short file-transfer command instead of the full pixels, allowing full-screen repaints to multiply load across terminal-browser, Herdr, and the terminal.

This keeps the fallback responsive to discrete changes after idle while bounding sustained full-frame output. It does not add a frame queue: the existing canvas remains the latest state and intermediate paints coalesce.

## Verification

- `cargo test --manifest-path engine/Cargo.toml -p pixel-core --lib`: 257 passed
- fail-before mutation restoring the 200 ms cap: `frame_debt_enforces_the_full_byte_budget` failed with 200 ms instead of 1.666 s
- real TTY acknowledgement test uses Herdr's `Gi=<id>,p=1;OK` reply and proves keys before and after the reply survive
- Rust 1.93 Clippy completed with only the pre-existing warnings
- release build of the exact commit completed in an isolated Rust 1.93 container
- live phone/Mosh fallback test at 1539×2001 with a five-updates-per-second full-frame producer:
  - Ghostty median 15% CPU
  - Herdr median 3% CPU
  - browser median 6% CPU
  - Baloo 0% CPU

The earlier unsafe 10 fps fallback experiment drove Ghostty to roughly 130–135% CPU; it is not part of this patch.

## Boundaries

Issue #48 reports the separate direct Herdr graphics-stream/WezTerm path. This PR protects the terminal fallback used when direct transport is unavailable and does not claim to fix #48.

PR #63 changes Herdr attach retry, stale frame cleanup, and layer placement in the same engine area. Those changes do not bound fallback frame load; the two efforts are logically complementary but may conflict mechanically.
