### PR TITLE
Fix shifted punctuation on non-US keyboard layouts (AZERTY / and ?)

### DIFF
--- a/browser/src/page/input.ts
+++ b/browser/src/page/input.ts
@@ -22,7 +22,7 @@ export class PageInput {
   private activeClickCount = 1;
   private wheelRemainderX = 0;
   private wheelRemainderY = 0;
-  private sentKeys = new Set<string>();
+  private sentKeys = new Map<string, string>();
   private superHeld = false;
   private focusGate: Promise<void> | null = null;
 
@@ -178,11 +178,14 @@ export class PageInput {
     }
     const keyCode = electronKey(event.key);
     if (event.kind === "release") {
-      if (!keyCode || !this.sentKeys.delete(event.key)) return;
-      const modifiers = this.modifiers(event.mods);
+      const sent = this.sentKeys.get(event.key);
+      this.sentKeys.delete(event.key);
+      if (!sent) return;
+      let modifiers = this.modifiers(event.mods);
+      if (sent !== keyCode) modifiers = modifiers.filter((m) => m !== "shift");
       if (event.key.startsWith("left")) modifiers.push("left");
       if (event.key.startsWith("right")) modifiers.push("right");
-      this.send({ type: "keyUp", keyCode, modifiers });
+      this.send({ type: "keyUp", keyCode: sent, modifiers });
       return;
     }
     this.syncFocus();
@@ -192,13 +195,21 @@ export class PageInput {
       }
       return;
     }
-    const modifiers = this.modifiers(event.mods);
+    let modifiers = this.modifiers(event.mods);
+    const printable = !!event.text && !event.mods.ctrl && !event.mods.super && !event.mods.alt;
+    // Electron resolves keyCode+modifiers against a US layout. When the
+    // engine's layout-resolved text disagrees (AZERTY shift+`:` types `/`),
+    // send that text as the keyCode and let Electron infer shift from it, so
+    // pages reading keydown.key (xterm.js) see the typed character.
+    const layoutText = printable && event.text!.length === 1 ? event.text! : null;
+    const sendKeyCode =
+      layoutText && layoutText !== usLayoutText(event.key, event.mods.shift) ? layoutText : keyCode;
+    if (sendKeyCode !== keyCode) modifiers = modifiers.filter((m) => m !== "shift");
     if (event.key.startsWith("left")) modifiers.push("left");
     if (event.key.startsWith("right")) modifiers.push("right");
     if (event.kind === "repeat") modifiers.push("isautorepeat");
-    this.sentKeys.add(event.key);
-    this.send({ type: "rawKeyDown", keyCode, modifiers });
-    const printable = !!event.text && !event.mods.ctrl && !event.mods.super && !event.mods.alt;
+    this.sentKeys.set(event.key, sendKeyCode);
+    this.send({ type: "rawKeyDown", keyCode: sendKeyCode, modifiers });
     if (printable) {
       this.send({ type: "char", keyCode: event.text!, modifiers });
     }
@@ -241,9 +252,7 @@ export class PageInput {
   }
 
   releaseKeys() {
-    for (const key of this.sentKeys) {
-      const keyCode = electronKey(key);
-      if (!keyCode) continue;
+    for (const [key, keyCode] of this.sentKeys) {
       const modifiers: Electron.InputEvent["modifiers"] = [];
       if (key.startsWith("left")) modifiers.push("left");
       if (key.startsWith("right")) modifiers.push("right");
@@ -437,6 +446,37 @@ function controlEditingCommands(event: EngineKeyEvent): string[] | null {
     default:
       return null;
   }
+}
+
+const US_SHIFTED: Record<string, string> = {
+  "1": "!",
+  "2": "@",
+  "3": "#",
+  "4": "$",
+  "5": "%",
+  "6": "^",
+  "7": "&",
+  "8": "*",
+  "9": "(",
+  "0": ")",
+  "-": "_",
+  "=": "+",
+  "[": "{",
+  "]": "}",
+  "\\": "|",
+  ";": ":",
+  "'": '"',
+  ",": "<",
+  ".": ">",
+  "/": "?",
+  "`": "~",
+  " ": " ",
+};
+
+export function usLayoutText(key: string, shift: boolean): string | null {
+  if (key.length !== 1 || key < " " || key > "~") return null;
+  if (key >= "a" && key <= "z") return shift ? key.toUpperCase() : key;
+  return shift ? (US_SHIFTED[key] ?? null) : key;
 }
 
 export function electronKey(key: string) {

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -358,7 +358,7 @@ impl Terminal {
 
         // would prefer if they weren't magic and linked to some known doc on the internet
         io.out().write_all(
-            b"\x1b[?1049h\x1b[?25l\x1b[?1003h\x1b[?1006h\x1b[?1016h\x1b[?1004h\x1b[?2004h\x1b[?2048h\x1b[>1u",
+            b"\x1b[?1049h\x1b[?25l\x1b[?1003h\x1b[?1006h\x1b[?1016h\x1b[?1004h\x1b[?2004h\x1b[?2048h\x1b[>5u",
         )?; // enable many reporting modes so we get info about mouse/keyboard
         io.out().flush()?;
 
@@ -426,7 +426,7 @@ impl Terminal {
     pub fn set_key_event_types(&mut self, enabled: bool) -> io::Result<()> {
         self.io.out().write_all(b"\x1b[<u")?;
         self.io.out()
-            .write_all(if enabled { b"\x1b[>27u" } else { b"\x1b[>1u" })?;
+            .write_all(if enabled { b"\x1b[>31u" } else { b"\x1b[>5u" })?;
         self.io.out().flush()
     }
 
@@ -1637,8 +1637,20 @@ fn parse_kitty_key(params: &[u8]) -> KeyEvent {
         key: key_from_codepoint(code),
         mods,
         kind,
-        text: associated_text(params),
+        text: associated_text(params).or_else(|| shifted_key_text(params, mods, kind)),
     }
+}
+
+/// On non-US layouts shift can produce a character the unshifted codepoint
+/// does not hint at (AZERTY shift+`:` types `/`). When the terminal reports
+/// the shifted key but no associated text, that shifted key is the text.
+fn shifted_key_text(params: &[u8], mods: Mods, kind: KeyKind) -> Option<String> {
+    if !mods.shift || mods.ctrl || mods.alt || mods.sup || kind == KeyKind::Release {
+        return None;
+    }
+    let shifted = char::from_u32(subparam(params, 0, 1)?)?;
+    (!shifted.is_control() && !('\u{e000}'..='\u{f8ff}').contains(&shifted))
+        .then(|| shifted.to_string())
 }
 
 fn key_from_codepoint(code: u32) -> Key {
@@ -2258,9 +2270,36 @@ mod tests {
         assert_eq!(
             parse_event(b"\x1b[99:67;5u"),
             Some((key_mods(Key::Char('c'), CTRL), 10)),
-            "sub-parameters (shifted key) are ignored"
+            "the shifted key is not text while ctrl is held"
         );
         assert_eq!(parse_event(b"\x1b[57428;1u"), Some((key(Key::Unknown), 10)));
+    }
+
+    #[test]
+    fn shifted_key_stands_in_for_missing_associated_text() {
+        let (event, _) = parse_event(b"\x1b[58:47;2u").unwrap();
+        assert!(
+            matches!(
+                &event,
+                RawEvent::Key(KeyEvent {
+                    key: Key::Char(':'),
+                    mods: SHIFT,
+                    text: Some(text),
+                    ..
+                }) if text == "/"
+            ),
+            "AZERTY shift+`:` types `/`: {event:?}"
+        );
+        let (event, _) = parse_event(b"\x1b[58:47;2;63u").unwrap();
+        assert!(
+            matches!(&event, RawEvent::Key(KeyEvent { text: Some(text), .. }) if text == "?"),
+            "associated text wins over the shifted key: {event:?}"
+        );
+        let (event, _) = parse_event(b"\x1b[58:47;2:3u").unwrap();
+        assert!(
+            matches!(&event, RawEvent::Key(KeyEvent { kind: KeyKind::Release, text: None, .. })),
+            "releases carry no text: {event:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Fix shifted punctuation on non-US keyboard layouts (AZERTY `/` and `?`)

Fixes zenbu-labs/terminal-code#6.

On a French AZERTY layout (macOS, Ghostty host), typing `/` (shift+`:`) or `?` (shift+`,`) in the embedded code-server's integrated terminal inserted nothing or the unshifted character. The layout-resolved character was lost twice on its way to the page:

1. **Engine.** The kitty keyboard protocol was enabled without flag 4 ("report alternate keys"), so only the unshifted codepoint was available. When a terminal reports no associated text either, the event carried no way to know shift+`:` types `/`.
2. **Electron.** `PageInput.key()` forwarded the unshifted keyCode plus a shift modifier to `sendInputEvent`, which Chromium resolves against a US layout. Pages that read `keydown.key` — xterm.js in particular — saw `:` (US shift+`;`) instead of `/`. The Monaco editor mostly survived because it consumes the separate `char` event, which already carried the right text; the integrated terminal did not.

### Changes

**engine (`terminal.rs`)**
- Request kitty flag 4 in both flag sets (`>1u` → `>5u`, `>27u` → `>31u`).
- `parse_kitty_key` now falls back to the reported shifted key as the event text when associated text is missing (shift-only presses, ignoring releases and PUA codepoints). This also fixes typing shifted punctuation into the engine's own text inputs (URL bar), which insert from `key.text`.
- Tests: `CSI 58:47;2u` → key `:` + shift + text `/`; associated text still wins over the shifted key; releases carry no text.

**browser (`input.ts`)**
- When the engine's layout-resolved text disagrees with what Electron's US-layout synthesis of (keyCode, shift) would produce (`usLayoutText`), send that text as the `rawKeyDown` keyCode and drop the shift modifier — Electron re-infers shift from the character, so `keydown.key` matches what was typed. US layouts and letters are byte-for-byte unaffected.
- `sentKeys` becomes a `Map` from engine key to the keyCode actually sent, so `keyUp` mirrors the substituted `keyDown` (the release event carries no text to recompute it from).

### Testing

- `cargo test -p pixel-core`: 253 passed (3 new).
- `tsc --noEmit` on the browser package: clean.
- Manual: built a local dist (`pnpm build:dist`) and ran tode v0.1.13 against it via `TODE_TERMINAL_BROWSER_BIN` in Ghostty with French AZERTY: `/`, `?` and the shifted digit row now insert correctly in the integrated terminal and the editor.
