### PR TITLE
Follow the display the terminal is on (fixes #16)

### DIFF
--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -20,7 +20,7 @@ import { BitmapPresenter, presentPaint, shmFrameOf } from "./paint";
 import { PopupWindow } from "./popup";
 import { cssSize, initialBrowserState } from "./types";
 import type { BrowserState, BrowserSurfaceLayout } from "./types";
-import { scaleZoom, stepZoom } from "./zoom";
+import { clampUserZoom, stepUserZoom } from "./zoom";
 import type { ZoomDirection } from "./zoom";
 
 export class BrowserController {
@@ -29,6 +29,8 @@ export class BrowserController {
   private readonly devtoolsSurface: Surface;
   private readonly window: BrowserWindow;
   private readonly onState: (state: BrowserState) => void;
+  private readonly zoomCorrection: () => number;
+  private userZoom = 1;
   private renderScale: number;
   private layout: BrowserSurfaceLayout;
   private state: BrowserState;
@@ -87,12 +89,14 @@ export class BrowserController {
     tabsAsPopups: boolean,
     clipboardRead: boolean,
     sessionKey: string,
+    zoomCorrection: () => number,
     onState: (state: BrowserState) => void,
   ) {
     this.partition = partition ? persistentPartition(partition) : null;
     this.tabsAsPopups = tabsAsPopups;
     this.clipboardRead = clipboardRead;
     this.sessionKey = sessionKey;
+    this.zoomCorrection = zoomCorrection;
     this.cwd = cwd;
     this.surface = surface;
     this.bitmaps = new BitmapPresenter(surface);
@@ -180,6 +184,8 @@ export class BrowserController {
     this.window.webContents.on("did-stop-loading", () => this.updateNavigation(false));
     this.window.webContents.on("did-navigate", (_event, url) => {
       if (urlHost(url) !== urlHost(this.state.url)) this.updateState({ favicon: null });
+      // a cross-origin navigation drops back to the session default
+      this.applyZoom();
       this.updateNavigation(false, url);
     });
     this.window.webContents.on("page-favicon-updated", (_event, favicons) => {
@@ -254,15 +260,34 @@ export class BrowserController {
   }
 
   zoom(direction: ZoomDirection): number {
-    const factor = stepZoom(this.window.webContents, direction);
-    this.updateState({ zoom: factor });
-    return factor;
+    this.userZoom = stepUserZoom(this.userZoom, direction);
+    return this.applyZoom();
   }
 
   scaleZoom(ratio: number): number {
-    const factor = scaleZoom(this.window.webContents, ratio);
-    this.updateState({ zoom: factor });
-    return factor;
+    this.userZoom = clampUserZoom(this.userZoom * ratio);
+    return this.applyZoom();
+  }
+
+  /** the display density changed: re-assert, the correction is read fresh */
+  applyDisplayCorrection(): void {
+    this.applyZoom();
+  }
+
+  /**
+   * Write the zoom factor absolutely, never as a multiplication of what is
+   * already there. Chromium keeps zoom per origin per partition, so the factor
+   * read back may have been written by another browser showing the same host;
+   * multiplying that compounds on every monitor move.
+   */
+  private applyZoom(): number {
+    if (this.stopped) return this.userZoom;
+    const want = this.userZoom * this.zoomCorrection();
+    const contents = this.window.webContents;
+    if (Math.abs(contents.getZoomFactor() - want) > 1e-4) contents.setZoomFactor(want);
+    for (const popup of this.popups) popup.setUserZoom(this.userZoom);
+    this.updateState({ zoom: this.userZoom });
+    return this.userZoom;
   }
 
   osPid(): number {
@@ -558,7 +583,7 @@ export class BrowserController {
       loading,
       canGoBack: this.window.webContents.navigationHistory.canGoBack(),
       canGoForward: this.window.webContents.navigationHistory.canGoForward(),
-      zoom: this.window.webContents.getZoomFactor(),
+      zoom: this.userZoom,
     });
   }
 
@@ -631,6 +656,8 @@ export class BrowserController {
       size,
       this.renderScale,
       () => this.layout.scale,
+      this.zoomCorrection,
+      () => this.userZoom,
       () => this.onPopupChange?.(),
       () => {
         const at = this.popups.indexOf(popup);

--- a/browser/src/page/popup.ts
+++ b/browser/src/page/popup.ts
@@ -3,7 +3,7 @@ import type { BrowserWindow } from "electron";
 import type { Surface } from "pixel-react";
 import { cursorShapeFor } from "./cursor";
 import { PageInput } from "./input";
-import { scaleZoom, stepZoom } from "./zoom";
+import { clampUserZoom, stepUserZoom } from "./zoom";
 import type { ZoomDirection } from "./zoom";
 
 export interface PopupState {
@@ -19,6 +19,8 @@ export class PopupWindow {
   cursorShape = "default";
   onCursorChange: (() => void) | null = null;
   private readonly window: BrowserWindow;
+  private readonly zoomCorrection: () => number;
+  private userZoom: number;
   private readonly surface: Surface;
   private readonly onChange: () => void;
   private readonly renderScale: number;
@@ -34,12 +36,16 @@ export class PopupWindow {
     size: { width: number; height: number },
     renderScale: number,
     scale: () => number,
+    zoomCorrection: () => number,
+    initialUserZoom: () => number,
     onChange: () => void,
     onClosed: () => void,
     openWindow?: (details: Electron.HandlerDetails) => Electron.WindowOpenHandlerResponse,
   ) {
     this.window = window;
     this.surface = surface;
+    this.zoomCorrection = zoomCorrection;
+    this.userZoom = initialUserZoom();
     this.onChange = onChange;
     this.renderScale = renderScale;
     this.stateValue = {
@@ -57,7 +63,10 @@ export class PopupWindow {
     });
     const contents = window.webContents;
     contents.on("page-title-updated", (_event, title) => this.update({ title }));
-    contents.on("did-navigate", (_event, url) => this.update({ url }));
+    contents.on("did-navigate", (_event, url) => {
+      this.setUserZoom(this.userZoom);
+      this.update({ url });
+    });
     contents.on("did-navigate-in-page", (_event, url, mainFrame) => {
       if (mainFrame) this.update({ url });
     });
@@ -94,11 +103,21 @@ export class PopupWindow {
   }
 
   zoom(direction: ZoomDirection): number {
-    return stepZoom(this.window.webContents, direction);
+    return this.setUserZoom(stepUserZoom(this.userZoom, direction));
   }
 
   scaleZoom(ratio: number): number {
-    return scaleZoom(this.window.webContents, ratio);
+    return this.setUserZoom(clampUserZoom(this.userZoom * ratio));
+  }
+
+  /** absolute, for the same reason BrowserController.applyZoom is */
+  setUserZoom(value: number): number {
+    this.userZoom = value;
+    if (this.destroyed) return this.userZoom;
+    const want = this.userZoom * this.zoomCorrection();
+    const contents = this.window.webContents;
+    if (Math.abs(contents.getZoomFactor() - want) > 1e-4) contents.setZoomFactor(want);
+    return this.userZoom;
   }
 
   setVisible(visible: boolean) {

--- a/browser/src/page/zoom.ts
+++ b/browser/src/page/zoom.ts
@@ -7,27 +7,23 @@ const ZOOM_PRESETS = [
 export type ZoomDirection = 1 | -1 | 0;
 
 
-export function stepZoom(contents: WebContents, direction: ZoomDirection): number {
-  const current = contents.getZoomFactor();
-  const factor =
-    direction === 0
-      ? 1
-      : direction === 1
-        ? (ZOOM_PRESETS.find((preset) => preset > current * 1.001) ?? ZOOM_PRESETS.at(-1)!)
-        : ([...ZOOM_PRESETS].reverse().find((preset) => preset < current * 0.999) ??
-          ZOOM_PRESETS[0]);
-  contents.setZoomFactor(factor);
-  return factor;
+/**
+ * The zoom factor Chromium holds is the user's zoom multiplied by the display
+ * correction (see DisplayScale), so callers track the user's own zoom and
+ * write the product. These helpers only move the user's number.
+ */
+export function stepUserZoom(current: number, direction: ZoomDirection): number {
+  if (direction === 0) return 1;
+  if (direction === 1) {
+    return ZOOM_PRESETS.find((preset) => preset > current * 1.001) ?? ZOOM_PRESETS.at(-1)!;
+  }
+  return [...ZOOM_PRESETS].reverse().find((preset) => preset < current * 0.999) ?? ZOOM_PRESETS[0];
 }
 
 
-export function scaleZoom(contents: WebContents, ratio: number): number {
-  const floor = ZOOM_PRESETS[0];
-  const ceiling = ZOOM_PRESETS.at(-1)!;
-  const exact = contents.getZoomFactor() * ratio;
-  const factor = Math.min(ceiling, Math.max(floor, Math.round(exact * 1000) / 1000));
-  contents.setZoomFactor(factor);
-  return factor;
+export function clampUserZoom(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 1;
+  return Math.min(ZOOM_PRESETS.at(-1)!, Math.max(ZOOM_PRESETS[0], Math.round(value * 1000) / 1000));
 }
 
 

--- a/browser/src/session/display-scale.ts
+++ b/browser/src/session/display-scale.ts
@@ -1,0 +1,177 @@
+import { screen } from "electron";
+import { displayPointSize, setDisplayPointSize } from "pixel-store";
+
+export type ScaleVerdict = {
+  scale: number;
+  kind: "display" | "font";
+  why: string;
+};
+
+/**
+ * Tracks the pixel density of the display the terminal is actually on.
+ *
+ * An offscreen window's deviceScaleFactor is fixed when the window is built,
+ * and `layout.scale` has to keep matching it or the painted frame stops
+ * matching the surface. So we keep both, and express the difference as a page
+ * zoom factor:
+ *
+ *     correction = effective / built
+ *
+ * Chromium computes `devicePixelRatio` as deviceScaleFactor x zoomFactor and
+ * divides the CSS viewport by the zoom, so a corrected page ends up with the
+ * viewport and the devicePixelRatio of the display it is really shown on, with
+ * no window rebuild and no lost page state.
+ */
+export class DisplayScale {
+  private built = 1;
+  private effective = 1;
+  /** the terminal's base cell metric in points, which a monitor move leaves alone */
+  private point = 0;
+
+  /** the scale the offscreen windows were, and stay, built with */
+  start(scale: number, basePx: number): void {
+    this.built = scale;
+    this.effective = scale;
+    this.point = basePx / scale;
+  }
+
+  get current(): number {
+    return this.effective;
+  }
+
+  get pointSize(): number {
+    return this.point;
+  }
+
+  correction(): number {
+    const value = this.effective / this.built;
+    if (!Number.isFinite(value) || value <= 0) return 1;
+    return Math.min(8, Math.max(0.125, value));
+  }
+
+  /**
+   * Work out the scale to build with, now that basePx is known.
+   *
+   * hostDisplayScale() has to guess, because it runs before the engine exists.
+   * It samples the display under the mouse cursor, and the cursor is often not
+   * where the window is. Getting it wrong is worse than any later mistake,
+   * because the point size everything else is measured against is derived from
+   * it: a session opened on a 2x panel while the cursor sat on a 1x monitor
+   * recorded a 26.32pt cell, and then read every monitor move as a font change.
+   *
+   * This runs before the layout is computed and before any offscreen window is
+   * built, so the scale the windows are built with ends up right.
+   */
+  startScale(basePx: number, cursorGuess: number): { scale: number; why: string; sure: boolean } {
+    const attached = this.known();
+    if (attached.length === 1) return { scale: attached[0], why: "single display", sure: true };
+    if (!(basePx > 0) || attached.length === 0) {
+      return { scale: cursorGuess, why: "no basePx", sure: false };
+    }
+    const remembered = displayPointSize();
+    if (remembered > 0) {
+      let best: number | null = null;
+      let bestError = Infinity;
+      for (const scale of attached) {
+        const value = Math.abs(basePx / scale - remembered) / remembered;
+        if (value < bestError) {
+          bestError = value;
+          best = scale;
+        }
+      }
+      if (best != null && bestError <= 0.15) {
+        return { scale: best, why: `remembered ${remembered.toFixed(2)}pt`, sure: true };
+      }
+    }
+    // No memory yet. A terminal cell is between about 8 and 24 points tall, so
+    // a scale implying anything outside that range is the wrong one.
+    const plausible = attached.filter((scale) => basePx / scale >= 8 && basePx / scale <= 24);
+    if (plausible.length === 1) {
+      return { scale: plausible[0], why: "only plausible cell size", sure: true };
+    }
+    return { scale: cursorGuess, why: "cursor guess", sure: false };
+  }
+
+  /** keep the point size, so the next session does not have to guess at all */
+  learn(): void {
+    setDisplayPointSize(this.point);
+  }
+
+  /**
+   * Decide what a change in the terminal's base cell metric means.
+   *
+   * The pane size is not a usable signal. macOS resizes a window when it moves
+   * between monitors, so the pane and the cell rarely move by the same factor;
+   * on a measured Retina-to-1x move the cell went to 0.52x while the pane went
+   * to 0.79x, which is why followCellZoom read it as a font change. What holds
+   * still is the cell size in POINTS, because basePx tracks the physical cell:
+   *
+   *   built-in Retina   basePx 26.32  at scale 2  ->  13.16 pt
+   *   DELL U3415W       basePx 13.59  at scale 1  ->  13.59 pt
+   *
+   * Reading 13.59 while we believe we are at scale 2 implies 6.79 pt, 48% away
+   * from the remembered 13.16. Scale 1 implies 13.59 pt, 3% away. Only a
+   * near-exact fit at a different scale counts, so a large font change is not
+   * mistaken for a monitor move.
+   */
+  classify(basePx: number): ScaleVerdict {
+    const current = this.effective;
+    const scales = this.known();
+    if (scales.length === 1 && scales[0] !== current) {
+      return { scale: scales[0], kind: "display", why: "single display attached" };
+    }
+    if (!(this.point > 0) || !(basePx > 0)) {
+      return { scale: current, kind: "font", why: "no point size yet" };
+    }
+    const error = (scale: number) => Math.abs(basePx / scale - this.point) / this.point;
+    const currentError = error(current);
+    if (currentError <= 0.25) {
+      return { scale: current, kind: "font", why: `current off ${currentError.toFixed(3)}` };
+    }
+    let best = current;
+    let bestError = currentError;
+    for (const scale of scales) {
+      const value = error(scale);
+      if (value < bestError) {
+        bestError = value;
+        best = scale;
+      }
+    }
+    if (best !== current && bestError <= 0.1) {
+      return {
+        scale: best,
+        kind: "display",
+        why: `${bestError.toFixed(3)} beats ${currentError.toFixed(3)}`,
+      };
+    }
+    return { scale: current, kind: "font", why: `nothing beats ${currentError.toFixed(3)}` };
+  }
+
+  /** adopt the cell size the terminal now reports as the reference point size */
+  remember(basePx: number, scale = this.effective): void {
+    if (basePx > 0 && scale > 0) this.point = basePx / scale;
+  }
+
+  /** returns true when the value moved, so the caller knows to re-apply zoom */
+  setEffective(scale: number): boolean {
+    if (!Number.isFinite(scale) || scale <= 0) return false;
+    if (Math.abs(scale - this.effective) < 1e-3) return false;
+    this.effective = scale;
+    return true;
+  }
+
+  /** every distinct scale factor the OS reports, so no monitor is hardcoded */
+  known(): number[] {
+    try {
+      const seen = new Set<number>();
+      for (const display of screen.getAllDisplays()) {
+        if (Number.isFinite(display.scaleFactor) && display.scaleFactor > 0) {
+          seen.add(display.scaleFactor);
+        }
+      }
+      return [...seen].sort((a, b) => a - b);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -4,7 +4,7 @@ import path from "node:path";
 import { app, ipcMain, screen } from "electron";
 import { createRequire } from "node:module";
 import type { IpcMainEvent, Session as ElectronSession } from "electron";
-import { createRoot } from "pixel-react";
+import { appLog, createRoot } from "pixel-react";
 import type { DragEvent, EngineKeyEvent, PixelRoot, Surface } from "pixel-react";
 import { detect } from "pixel-terminals";
 import type { Pane, Terminal } from "pixel-terminals";
@@ -16,6 +16,7 @@ import {
 } from "../page/browser-session";
 import type { DownloadProgress } from "../page/browser-session";
 import { BrowserController } from "../page/controller";
+import { DisplayScale } from "./display-scale";
 import { initOffscreenMode } from "../page/offscreen";
 import { initialBrowserState } from "../page/types";
 import type { BrowserState, BrowserSurfaceLayout } from "../page/types";
@@ -192,6 +193,7 @@ class Session {
   private surfaceLayout: BrowserSurfaceLayout | null = null;
   private devtoolsLayout: BrowserSurfaceLayout | null = null;
   private displayScale = 1;
+  private readonly display = new DisplayScale();
   private fontId = 0;
   private windowBg = "#1e2026";
 
@@ -270,6 +272,7 @@ class Session {
             this.tabsAsPopups,
             this.clipboardRead,
             this.ctx.key,
+            () => this.display.correction(),
             onState,
           ),
         onActivated: () => {
@@ -356,6 +359,19 @@ class Session {
     this.applyKeyBindings(this.root.info.kittyKeyboard);
     this.popupSurface = this.root.createSurface();
     this.devtoolsSurface = this.root.createSurface();
+    // hostDisplayScale had to guess before the engine existed; basePx is known
+    // now, and this still runs before the layout and before any offscreen
+    // window is built
+    const start = this.display.startScale(this.root.info.basePx, this.displayScale);
+    this.displayScale = start.scale;
+    this.display.start(start.scale, this.root.info.basePx);
+    if (start.sure) this.display.learn();
+    appLog(
+      "info",
+      "scale",
+      `start ${start.scale}x (${start.why}), basePx ${this.root.info.basePx.toFixed(2)}, ` +
+        `point ${this.display.pointSize.toFixed(2)}`,
+    );
     this.followCellZoom();
     this.recalculateLayout();
     this.root.setPointerShape("default");
@@ -986,6 +1002,7 @@ class Session {
     if (!prev || !prev.basePx || !prev.height) return;
     const ratio = basePx / prev.basePx;
     if (!Number.isFinite(ratio) || ratio <= 0 || Math.abs(ratio - 1) < 0.01) return;
+    if (this.followCellScale(basePx)) return;
     const paneRatio = height / prev.height;
     if (Math.abs(paneRatio - ratio) < 0.04 * ratio) return;
     let hud: number | null = null;
@@ -996,6 +1013,51 @@ class Session {
     });
     if (active?.popup) hud = active.popup.scaleZoom(ratio);
     if (hud != null) this.showZoomHud(hud);
+  }
+
+  /**
+   * The terminal reported a new cell size. Returns true when that means the
+   * window moved to a display of a different density, in which case the caller
+   * must not also zoom the page.
+   */
+  private followCellScale(basePx: number): boolean {
+    const previous = this.display.pointSize;
+    const verdict = this.display.classify(basePx);
+    appLog(
+      "info",
+      "scale",
+      `basePx ${basePx.toFixed(2)} point ${previous.toFixed(2)} ` +
+        `scale ${this.display.current} -> ${verdict.scale} ${verdict.kind} (${verdict.why})`,
+    );
+    this.display.remember(basePx, verdict.scale);
+    if (verdict.kind === "display") {
+      this.setDisplayScale(verdict.scale);
+      return true;
+    }
+    // The cell is exactly what the current scale predicts, so in point terms
+    // nothing changed and the move has already been accounted for. A real font
+    // change always shifts the point size. Chromium keeps zoom per origin per
+    // partition, so two browsers on one host share a factor; without this the
+    // second would zoom the shared page a second time.
+    if (previous > 0 && Math.abs(basePx / this.display.current - previous) / previous < 0.01) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * An offscreen window's deviceScaleFactor cannot change after it is built,
+   * and layout.scale has to keep matching it or the painted frame stops
+   * matching the surface. So the new density is applied as a page zoom factor,
+   * which gives the page both the right CSS viewport and the right
+   * devicePixelRatio without rebuilding anything.
+   */
+  private setDisplayScale(scale: number) {
+    if (!this.display.setEffective(scale)) return;
+    this.tabs.eachController((controller) => controller.applyDisplayCorrection());
+    this.display.learn();
+    appLog("info", "scale", `display scale ${scale}x, correction ${this.display.correction()}`);
+    this.render();
   }
 
   private showZoomHud(factor: number) {

--- a/engine/crates/pixel-core/src/herdr.rs
+++ b/engine/crates/pixel-core/src/herdr.rs
@@ -29,6 +29,11 @@ pub(crate) struct Herdr {
     frames: BufReader<UnixStream>,
     directory: PathBuf,
     cell: (u32, u32),
+    /// kept so the cell size can be asked for again; it changes when the
+    /// terminal window moves to a display with a different pixel density
+    pane: String,
+    socket: String,
+    last_canvas: (u32, u32),
     files: Vec<FrameFile>,
     retired: Vec<FrameFile>,
     instance: u64,
@@ -87,6 +92,9 @@ impl Herdr {
             frames,
             directory,
             cell,
+            pane: pane.to_string(),
+            socket: socket.to_string(),
+            last_canvas: (0, 0),
             files: Vec::new(),
             retired: Vec::new(),
             instance: 0,
@@ -120,7 +128,50 @@ impl Herdr {
         (x.saturating_sub(1), y.saturating_sub(1))
     }
 
+    /// Ask herdr for the cell size again.
+    ///
+    /// It is read once, in `connect`, but it changes whenever the terminal
+    /// window moves to a display with a different pixel density: 15x31 on a 2x
+    /// panel against 7x16 on a 1x monitor. `present` divides the canvas by it
+    /// to get the placement grid, so a stale value puts the frame over roughly
+    /// half the columns and half the rows and leaves the page in a corner of
+    /// the pane.
+    fn refresh_cell(&mut self) {
+        let Ok(info) = request(
+            &self.socket,
+            &format!(
+                r#"{{"id":"info","method":"pane.graphics.info","params":{{"pane_id":{}}}}}"#,
+                quote(&self.pane)
+            ),
+        ) else {
+            return;
+        };
+        let (Some(width), Some(height)) = (
+            field_u32(&info, "cell_width_px"),
+            field_u32(&info, "cell_height_px"),
+        ) else {
+            return;
+        };
+        if width == 0 || height == 0 || (width, height) == self.cell {
+            return;
+        }
+        crate::logging::info(
+            "herdr",
+            format!(
+                "cell size {}x{} -> {}x{}",
+                self.cell.0, self.cell.1, width, height
+            ),
+        );
+        self.cell = (width, height);
+    }
+
     pub(crate) fn present(&mut self, canvas: &Canvas) -> io::Result<usize> {
+        // only on a resize, so the steady state costs nothing; a density change
+        // always resizes the canvas, because the pane pixel size changes
+        if self.last_canvas != (canvas.width, canvas.height) {
+            self.last_canvas = (canvas.width, canvas.height);
+            self.refresh_cell();
+        }
         let path = crate::profiler::span("herdr.handoff", || self.write_frame(&canvas.pixels))?;
         let header = format!(
             r#"{{"format":"rgba","image_width":{},"image_height":{},"file":{{"path":{}}},"sequence":{},"revision":0,"placement":{{"viewport_col":0,"viewport_row":0,"grid_cols":{},"grid_rows":{}}}}}"#,

--- a/store/src/app-state.ts
+++ b/store/src/app-state.ts
@@ -23,3 +23,12 @@ export function lastUrl(): string | null {
 export function setLastUrl(url: string): void {
   setAppState("last-url", url);
 }
+
+export function displayPointSize(): number {
+  const value = Number(getAppState("display-point-size"));
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+export function setDisplayPointSize(value: number): void {
+  if (value > 0) setAppState("display-point-size", String(value));
+}

--- a/store/src/index.ts
+++ b/store/src/index.ts
@@ -14,4 +14,9 @@ export type { Store } from "./client";
 export { appState, instances, settings } from "./schema";
 export type { DevtoolsDock, InstanceRow, NewInstanceRow, SettingsRow } from "./schema";
 export { listInstances, removeInstance, upsertInstance } from "./instances";
-export { lastUrl, setLastUrl } from "./app-state";
+export {
+  displayPointSize,
+  lastUrl,
+  setDisplayPointSize,
+  setLastUrl,
+} from "./app-state";


### PR DESCRIPTION
Two independent bugs show up when the terminal window moves between displays of different pixel density. Measured on macOS 26.6 with Ghostty, across a 2x built-in panel (cell 15x31) and a 1x DELL U3415W (cell 7x16).

The engine commit stands alone and is the smaller review; the browser commit fixes #16.

---

## 1. `fix(engine)` — the herdr cell size is read once and never refreshed

`Herdr::connect` reads `cell_width_px` / `cell_height_px` from `pane.graphics.info` at construction. `Herdr::present` then divides the canvas by that cached value to get the placement grid, so after a density change the frame is placed over the wrong number of cells. On a 651x608 px pane over 93x38 cells:

| | correct | stale | |
|---|---|---|---|
| `grid_cols` | 651 / 7 = 93 | 651 / 15 = 44 | 47% |
| `grid_rows` | 608 / 16 = 38 | 608 / 31 = 20 | 53% |

About half in each direction, so the page lands in the top-left quarter of the pane with stale pixels around it. Moving the other way over-spans. It is symmetric and deterministic — correct on the display the browser was opened on, wrong on the other — and nudging or resizing the window does not clear it.

Worth noting that `Engine::cell`, which comes from the tty, already refreshes and even has `forget_cell_size`. Only this herdr path was missing it, which is why `basePx` looked correct throughout and made this hard to spot.

The fix re-queries on a canvas size change. A density change always resizes the canvas, so that is the exact trigger and the steady state costs nothing.

## 2. `fix(browser)` — the page scale does not follow the display (#16)

Three causes:

**The start scale.** `hostDisplayScale` samples the display under the mouse cursor, which is often not where the window is. It has to guess, since it runs before the engine exists and so before `basePx` is known. Getting it wrong poisons everything downstream, because the reference point size is derived from it: a session opened on the 2x panel while the cursor sat on the 1x monitor recorded a 26.32 pt cell and then read every later move as a font change. `DisplayScale.startScale` re-derives it once `basePx` arrives, still before the layout is computed and before any offscreen window is built.

**Detection.** `followCellZoom` separated a font change from a monitor move by comparing the cell ratio with the pane ratio. That does not hold, because macOS resizes the window when it changes display — a measured move gave a cell ratio of 0.52 against a pane ratio of 0.79, so the move fell through and multiplied the page zoom by ~1.94 instead. What holds still is the cell size in **points**:

```
built-in Retina   basePx 26.32  at scale 2  ->  13.16 pt
DELL U3415W       basePx 13.59  at scale 1  ->  13.59 pt
```

Reading 13.59 while believing we are at 2x implies 6.79 pt, 48% off the remembered 13.16; 1x implies 13.59 pt, 3% off. Only a near-exact fit at a different scale wins, so a large font change is not mistaken for a move. Candidates come from `screen.getAllDisplays()`, so no monitor is hardcoded.

**Application.** An offscreen window's `deviceScaleFactor` is fixed at construction, and `layout.scale` has to keep matching it or the painted frame stops matching the surface. So the difference is applied as a page zoom factor, `correction = effective / built`. Chromium computes `devicePixelRatio` as `deviceScaleFactor x zoomFactor` and divides the CSS viewport by the zoom, so the page gets both a correct viewport and a correct `devicePixelRatio` with no window rebuild and no lost page state.

Zoom is also now written absolutely rather than multiplied. Chromium keeps zoom per origin per partition, so the factor read back may have been written by another browser showing the same host; multiplying compounded on every move and reached `devicePixelRatio` 3.875 here.

---

## Verification

On the 2x panel `devicePixelRatio` is 2 and the viewport is exactly half the pane's physical width; on the 1x monitor they are 1 and equal. Real moves produce one display verdict per session and no font verdict. The page fills the pane on both displays across repeated moves.

The two fixes are independent: with the browser commit reverted and the engine commit alone applied, the same pane reports `devicePixelRatio` 1 and a doubled viewport.

`tsc --noEmit` is clean in `browser/` and `store/`, and `cargo build -p pixel-node --release` succeeds.

## Notes

- The design choice worth a look is the page-zoom correction. It is the only lever available while an offscreen window's `deviceScaleFactor` stays fixed at construction; happy to rework it if you would rather rebuild the window on a density change.
- One ambiguity the cell size cannot resolve: exactly doubling the terminal font on a 1x display is indistinguishable from moving to a 2x display. `TERMINAL_BROWSER_DISPLAY_SCALE` still overrides everything.
- @Pallavikumarimdb was assigned #16 in August — apologies if this overlaps with work in progress, happy to defer or split it.
