### PR TITLE
fix(all): dynamic display scaling, Herdr cell metrics refresh, and smooth resize

### DIFF
--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -226,10 +226,19 @@ export class BrowserController {
     }
     this.layout = layout;
     this.renderScale = browserRenderScale(layout);
-    // why keep frame?
-    if (!options?.keepFrame) this.surface.clear();
+    if (options?.keepFrame === false) this.surface.clear();
     const size = this.contentSize(layout);
     this.window.setContentSize(size.width, size.height, false);
+    void this.attachCdp()
+      .then(() =>
+        this.cdp("Emulation.setDeviceMetricsOverride", {
+          width: size.width,
+          height: size.height,
+          deviceScaleFactor: this.renderScale,
+          mobile: false,
+        }),
+      )
+      .catch(() => {});
   }
 
   navigate(value: string) {
@@ -674,8 +683,7 @@ export class BrowserController {
     };
   }
 }
-
-function browserRenderScale(layout: BrowserSurfaceLayout) {
+export function browserRenderScale(layout: BrowserSurfaceLayout) {
   const explicit = Number(process.env.TERMINAL_BROWSER_RENDER_SCALE);
   if (Number.isFinite(explicit) && explicit > 0) {
     return Math.max(0.5, Math.min(layout.scale, explicit));

--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -73,7 +73,7 @@ export class BrowserController {
   onDevtoolsAction: ((action: DevtoolsAction) => void) | null = null;
   onContextMenu: ((params: Electron.ContextMenuParams) => void) | null = null;
   onClosed: (() => void) | null = null;
-
+  private resizeSeq = 0;
   constructor(
     surface: Surface,
     popupSurface: Surface,
@@ -229,15 +229,18 @@ export class BrowserController {
     if (options?.keepFrame === false) this.surface.clear();
     const size = this.contentSize(layout);
     this.window.setContentSize(size.width, size.height, false);
+    const seq = ++this.resizeSeq;
     void this.attachCdp()
-      .then(() =>
-        this.cdp("Emulation.setDeviceMetricsOverride", {
-          width: size.width,
-          height: size.height,
-          deviceScaleFactor: this.renderScale,
-          mobile: false,
-        }),
-      )
+      .then(() => {
+        if (seq === this.resizeSeq) {
+          return this.cdp("Emulation.setDeviceMetricsOverride", {
+            width: size.width,
+            height: size.height,
+            deviceScaleFactor: this.renderScale,
+            mobile: false,
+          });
+        }
+      })
       .catch(() => {});
   }
 

--- a/browser/src/page/devtools.ts
+++ b/browser/src/page/devtools.ts
@@ -29,6 +29,7 @@ export class DevtoolsWindow {
   cursorShape = "default";
   onCursorChange: ((shape: string) => void) | null = null;
   private renderScale: number;
+  private resizeSeq = 0;
   private readonly onDisplayChange = () => {
     if (this.destroyed) return;
     this.window.webContents.setFrameRate(this.visible ? frameRate() : 4);
@@ -142,15 +143,18 @@ export class DevtoolsWindow {
     if (options?.keepFrame === false) this.surface.clear();
     const size = cssSize(layout.width, layout.height, layout.scale);
     this.window.setContentSize(size.width, size.height, false);
+    const seq = ++this.resizeSeq;
     void this.attachCdp()
-      .then(() =>
-        this.cdp("Emulation.setDeviceMetricsOverride", {
-          width: size.width,
-          height: size.height,
-          deviceScaleFactor: this.renderScale,
-          mobile: false,
-        }),
-      )
+      .then(() => {
+        if (seq === this.resizeSeq) {
+          return this.cdp("Emulation.setDeviceMetricsOverride", {
+            width: size.width,
+            height: size.height,
+            deviceScaleFactor: this.renderScale,
+            mobile: false,
+          });
+        }
+      })
       .catch(() => {});
   }
 

--- a/browser/src/page/devtools.ts
+++ b/browser/src/page/devtools.ts
@@ -7,9 +7,8 @@ import { frameRate } from "./frame-rate";
 import { PageInput } from "./input";
 import { offscreenPreferences } from "./offscreen";
 import { BitmapPresenter, presentPaint, shmFrameOf } from "./paint";
-import { cssSize } from "./types";
-import type { BrowserSurfaceLayout } from "./types";
-
+import { cssSize, type BrowserSurfaceLayout } from "./types";
+import { browserRenderScale } from "./controller";
 export type DevtoolsAction = "close" | "dock-bottom" | "dock-right";
 
 export class DevtoolsWindow {
@@ -29,6 +28,7 @@ export class DevtoolsWindow {
   private pendingPanel: string | null = null;
   cursorShape = "default";
   onCursorChange: ((shape: string) => void) | null = null;
+  private renderScale: number;
   private readonly onDisplayChange = () => {
     if (this.destroyed) return;
     this.window.webContents.setFrameRate(this.visible ? frameRate() : 4);
@@ -49,6 +49,7 @@ export class DevtoolsWindow {
     this.bitmaps = new BitmapPresenter(surface);
     this.layout = layout;
     this.dock = dock;
+    this.renderScale = renderScale;
     this.onAction = onAction;
     this.window = new BrowserWindow({
       ...cssSize(layout.width, layout.height, layout.scale),
@@ -137,9 +138,20 @@ export class DevtoolsWindow {
       return;
     }
     this.layout = layout;
-    if (!options?.keepFrame) this.surface.clear();
+    this.renderScale = browserRenderScale(layout);
+    if (options?.keepFrame === false) this.surface.clear();
     const size = cssSize(layout.width, layout.height, layout.scale);
     this.window.setContentSize(size.width, size.height, false);
+    void this.attachCdp()
+      .then(() =>
+        this.cdp("Emulation.setDeviceMetricsOverride", {
+          width: size.width,
+          height: size.height,
+          deviceScaleFactor: this.renderScale,
+          mobile: false,
+        }),
+      )
+      .catch(() => {});
   }
 
   showPanel(panel: string) {

--- a/browser/src/session/display_scale_tracking.test.ts
+++ b/browser/src/session/display_scale_tracking.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+
+// Simulation of Session's displayScale management
+class MockSession {
+  displayScale: number;
+  layoutScale: number;
+  private env: Record<string, string>;
+  private mockCursorScale: number;
+
+  constructor(env: Record<string, string>, initialCursorScale: number) {
+    this.env = env;
+    this.mockCursorScale = initialCursorScale;
+    this.displayScale = this.hostDisplayScale();
+    this.layoutScale = this.displayScale;
+  }
+
+  hostDisplayScale() {
+    const explicit = Number(this.env.TERMINAL_BROWSER_DISPLAY_SCALE);
+    if (Number.isFinite(explicit) && explicit > 0) return explicit;
+    return this.mockCursorScale;
+  }
+
+  // Current session.tsx behavior: no display change handler, onResize doesn't update displayScale
+  onResizeCurrent() {
+    // Current behavior in session.tsx:
+    // this.followCellZoom();
+    // this.recalculateLayout(); // uses this.displayScale (stale!)
+    this.layoutScale = this.displayScale;
+  }
+
+  // Desired behavior: updates displayScale when screen metrics or display changes
+  onResizeFixed() {
+    const newScale = this.hostDisplayScale();
+    if (newScale !== this.displayScale) {
+      this.displayScale = newScale;
+    }
+    this.layoutScale = this.displayScale;
+  }
+
+  moveDisplay(newScale: number) {
+    this.mockCursorScale = newScale;
+  }
+}
+
+// Test Current Behavior vs Fixed Behavior:
+console.log("Running Phase 1 reproduction test for display scale tracking...");
+
+// 1. Start on 1x display
+const session = new MockSession({}, 1);
+assert.strictEqual(session.displayScale, 1, "Initial scale should be 1");
+assert.strictEqual(session.layoutScale, 1, "Initial layout scale should be 1");
+
+// 2. User moves window to 2x small Retina display
+session.moveDisplay(2);
+
+// 3. User resizes or screen metrics change
+session.onResizeCurrent();
+
+// ASSERTION THAT GOES RED ON CURRENT CODE:
+try {
+  assert.strictEqual(session.layoutScale, 2, "FAIL: layoutScale remained stale at 1 when moved to 2x display!");
+  console.log("Unexpected: current code passed?");
+} catch (err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.log("REPRODUCED (RED):", msg);
+}
+
+// 4. Verify fixed behavior
+session.onResizeFixed();
+assert.strictEqual(session.layoutScale, 2, "PASS: layoutScale successfully updated to 2 on 2x display");
+console.log("Verified: fixed behavior works!");

--- a/browser/src/session/layout.test.ts
+++ b/browser/src/session/layout.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert";
+import { computeLayout } from "./layout";
+import type { EngineInfo } from "pixel-react";
+
+// Test: Verify computeLayout behaves deterministically across different scale factors (1x vs 2x)
+const baseInfo: EngineInfo = {
+  width: 1600,
+  height: 800,
+  basePx: 16,
+  cellWidth: 8,
+  cellHeight: 16,
+  colors: {
+    foreground: [255, 255, 255, 255],
+    background: [0, 0, 0, 255],
+    palette: [],
+  },
+  kittyKeyboard: false,
+};
+
+// On 1x display (scale = 1)
+const layout1x = computeLayout(baseInfo, 1, false, false, null);
+assert.strictEqual(layout1x.surface.scale, 1);
+assert.strictEqual(layout1x.surface.width, 1590); // ~1600 minus pad
+assert.strictEqual(layout1x.surface.height, 763);
+
+// On 2x display (scale = 2)
+const layout2x = computeLayout(baseInfo, 2, false, false, null);
+assert.strictEqual(layout2x.surface.scale, 2);
+assert.strictEqual(layout2x.surface.width, 1590);
+assert.strictEqual(layout2x.surface.height, 762);
+
+console.log("computeLayout test passed!");

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -312,6 +312,7 @@ class Session {
     await this.loadDevtoolsSettings();
     if (!this.ctx.tty) process.stdout.write(`\x1b]2;${this.marker}\x07`);
     this.displayScale = this.hostDisplayScale();
+    if (this.shuttingDown) return;
     this.root = createRoot({
       tty: this.ctx.tty,
       wrapper: this.terminal?.wrapper,
@@ -353,6 +354,12 @@ class Session {
     });
     initOffscreenMode(this.root.sharedTextures);
     this.fontId = await this.root.registerFont(bundledFontPath());
+    if (this.shuttingDown) {
+      const root = this.root;
+      this.root = null;
+      root?.stop();
+      return;
+    }
     this.applyKeyBindings(this.root.info.kittyKeyboard);
     this.popupSurface = this.root.createSurface();
     this.devtoolsSurface = this.root.createSurface();
@@ -361,6 +368,9 @@ class Session {
     this.root.setPointerShape("default");
     this.windowBg = this.themeBackground();
     this.installEmbedderApi();
+    screen.on("display-added", this.onDisplayChange);
+    screen.on("display-removed", this.onDisplayChange);
+    screen.on("display-metrics-changed", this.onDisplayChange);
     this.tabs.create(this.fallbackState.url);
     this.registry = new Registry({
       key: this.ctx.key,
@@ -479,6 +489,9 @@ class Session {
     this.shuttingDown = true;
     ipcMain.removeListener("terminal-browser:theme-request", this.onThemeRequest);
     ipcMain.removeListener("terminal-browser:quit", this.onQuitRequest);
+    screen.off("display-added", this.onDisplayChange);
+    screen.off("display-removed", this.onDisplayChange);
+    screen.off("display-metrics-changed", this.onDisplayChange);
     for (const record of this.records.values()) record.dispose();
     this.records.clear();
     this.shownRecord = null;
@@ -495,12 +508,18 @@ class Session {
       this.popupSurface?.close();
       this.devtoolsSurface?.close();
     } catch { }
-    this.root?.stop();
+    const root = this.root;
+    this.root = null;
+    root?.stop();
     this.ctx.onClose(code);
   }
-
   nudgeResize() {
     this.root?.nudgeResize();
+    this.followCellZoom();
+    this.recalculateLayout();
+    if (this.surfaceLayout) this.tabs.activeController?.resize(this.surfaceLayout, { keepFrame: true });
+    if (this.devtoolsLayout) this.tabs.activeController?.devtools?.resize(this.devtoolsLayout, { keepFrame: true });
+    this.render();
   }
 
   private themePayload(): {
@@ -1398,10 +1417,18 @@ class Session {
     const query = this.palette.query.toLowerCase();
     return this.paletteActions().filter((action) => action.label.toLowerCase().includes(query));
   }
+  private readonly onDisplayChange = () => {
+    this.recalculateLayout();
+    if (this.surfaceLayout) this.tabs.activeController?.resize(this.surfaceLayout, { keepFrame: true });
+    if (this.devtoolsLayout) this.tabs.activeController?.devtools?.resize(this.devtoolsLayout, { keepFrame: true });
+    this.render();
+  };
+
 
   private recalculateLayout(placement: DevtoolsPlacement | null = this.devtoolsPlacement()) {
     if (!this.root) return;
     const reviewing = this.activeRecord()?.reviewing ?? false;
+    this.displayScale = this.hostDisplayScale();
     const result = computeLayout(
       this.root.info,
       this.displayScale,
@@ -1441,13 +1468,10 @@ class Session {
       height: Math.max(60, Math.min(Math.round(popup.state.height * scale), maxH)),
     };
   }
-
   private hostDisplayScale() {
     const explicit = Number(this.ctx.env.TERMINAL_BROWSER_DISPLAY_SCALE);
     if (Number.isFinite(explicit) && explicit > 0) return explicit;
-    if (this.terminal?.reportsCssPixels) return 1;
-    // this is a bit hacky i would like to improve on it
-    return screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).scaleFactor;
+    return 1;
   }
 
   private initialUrl(): string {

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -1471,7 +1471,15 @@ class Session {
   private hostDisplayScale() {
     const explicit = Number(this.ctx.env.TERMINAL_BROWSER_DISPLAY_SCALE);
     if (Number.isFinite(explicit) && explicit > 0) return explicit;
-    return 1;
+    if (this.terminal?.reportsCssPixels) return 1;
+    if (this.root?.info?.cellHeight) {
+      return this.root.info.cellHeight > 24 ? 2 : 1;
+    }
+    try {
+      return screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).scaleFactor;
+    } catch {
+      return 1;
+    }
   }
 
   private initialUrl(): string {

--- a/engine/crates/pixel-core/src/herdr.rs
+++ b/engine/crates/pixel-core/src/herdr.rs
@@ -1,8 +1,8 @@
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead as _, BufReader, Write as _};
+use std::num::NonZeroU32;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::Duration;
-
 use crate::canvas::Canvas;
 use crate::terminal::FrameFile;
 
@@ -28,7 +28,7 @@ impl HerdrTarget {
 pub(crate) struct Herdr {
     frames: BufReader<UnixStream>,
     directory: PathBuf,
-    cell: (u32, u32),
+    cell: (NonZeroU32, NonZeroU32),
     files: Vec<FrameFile>,
     retired: Vec<FrameFile>,
     instance: u64,
@@ -58,12 +58,9 @@ impl Herdr {
         }
         let directory = PathBuf::from(field_str(&info, "file_frame_directory")?);
         let cell = (
-            field_u32(&info, "cell_width_px")?,
-            field_u32(&info, "cell_height_px")?,
+            NonZeroU32::new(field_u32(&info, "cell_width_px")?)?,
+            NonZeroU32::new(field_u32(&info, "cell_height_px")?)?,
         );
-        if cell.0 == 0 || cell.1 == 0 {
-            return None;
-        }
 
         let stream = UnixStream::connect(socket).ok()?;
         stream.set_read_timeout(Some(OPEN_TIMEOUT)).ok()?;
@@ -96,7 +93,13 @@ impl Herdr {
     }
 
     pub(crate) fn cell(&self) -> (u32, u32) {
-        self.cell
+        (self.cell.0.get(), self.cell.1.get())
+    }
+
+    pub(crate) fn update_cell(&mut self, cell: (u32, u32)) {
+        if let (Some(w), Some(h)) = (NonZeroU32::new(cell.0), NonZeroU32::new(cell.1)) {
+            self.cell = (w, h);
+        }
     }
 
     pub(crate) fn mouse_position_px(
@@ -108,7 +111,7 @@ impl Herdr {
         pixel_mouse: bool,
         grid: impl FnOnce() -> Option<crate::terminal::WindowSize>,
     ) -> (u32, u32) {
-        let (cell_w, cell_h) = self.cell;
+        let (cell_w, cell_h) = (self.cell.0.get(), self.cell.1.get());
         let cell_center =
             |x: u32, y: u32| ((x - 1) * cell_w + cell_w / 2, (y - 1) * cell_h + cell_h / 2);
         if !pixel_mouse {
@@ -128,8 +131,8 @@ impl Herdr {
             canvas.height,
             quote(&path),
             self.seq,
-            canvas.width.div_ceil(self.cell.0).max(1),
-            canvas.height.div_ceil(self.cell.1).max(1),
+            canvas.width.div_ceil(self.cell.0.get()).max(1),
+            canvas.height.div_ceil(self.cell.1.get()).max(1),
         );
         self.seq += 1;
         write_line(self.frames.get_mut(), &header)?;

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -570,7 +570,7 @@ impl Terminal {
                 }
             }
         }
-        let current_cell = self.size().ok().and_then(|ws| ws.cell_size());
+        let current_cell = self.cell_size().ok().flatten();
         if let Some(herdr) = self.herdr.as_mut() {
             if let Some(cell) = current_cell {
                 herdr.update_cell(cell);

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -570,7 +570,11 @@ impl Terminal {
                 }
             }
         }
+        let current_cell = self.size().ok().and_then(|ws| ws.cell_size());
         if let Some(herdr) = self.herdr.as_mut() {
+            if let Some(cell) = current_cell {
+                herdr.update_cell(cell);
+            }
             match herdr.present(canvas) {
                 Ok(written) => return Ok(written),
                 Err(err) => {

--- a/engine/crates/pixel-node/src/lib.rs
+++ b/engine/crates/pixel-node/src/lib.rs
@@ -311,7 +311,7 @@ impl PixelEngine {
         let mut engine = Engine::new(EngineConfig {
             fonts,
             cell_metrics_font: 1,
-            watch_resize: false,
+            watch_resize: tty.is_some(),
             tty,
             wrapper: pixel_core::wrapper::Wrapper::named(wrapper.as_deref()),
             session_env,


### PR DESCRIPTION
## Summary
Fixes cross-display scaling, 1/4 quadrant placement bugs, and resize flickering across multi-monitor setups (e.g. 2x Retina ↔ 1x external display).

## Changes

### 1. `fix(engine)`: Dynamic Herdr cell metrics refresh & `NonZeroU32` hardening (#70)
- **Problem**: `Herdr::connect` previously cached cell dimensions once at construction. When moving across displays of different pixel densities (e.g. `16x32` on Retina to `8x16` on external 1x), `Herdr::present` computed `grid_cols` and `grid_rows` with the stale divisor, placing the canvas in a /4$ quadrant corner.
- **Fix**: 
  - Refactored `Herdr.cell` to `(NonZeroU32, NonZeroU32)` to guarantee non-zero divisor safety at compile time.
  - Added `Herdr::update_cell` and updated cell dimensions from live `TIOCGWINSZ` cell metrics before presenting frames.
  - Enabled `watch_resize: tty.is_some()` so TTY engines listen for terminal `SIGWINCH` signals.

### 2. `fix(browser)`: Smooth resize & dynamic Chromium rasterization scale (#16)
- **Problem**: 
  - Resizing the pane previously caused violent black-frame flickering because `this.surface.clear()` was called on every resize tick before the new frame arrived.
  - Moving across displays left Chromium offscreen rasterizer stuck at construction-time scale factors.
  - CLI resize notifications (`cmd: resize`) only pushed empty ops without running layout recalculation.
- **Fix**:
  - Preserved the previous frame texture during resize (`keepFrame` defaulted to true) to eliminate black strobe flicker.
  - Wired `nudgeResize()` to trigger the full layout recalculation and controller resize pipeline.
  - Added CDP `Emulation.setDeviceMetricsOverride` synchronization on dimensions and device scale changes to ensure live, crisp rasterization.
  - Added screen metric change listeners and idempotent teardown handling in `Session`.

Closes #16
Closes #70