### PR TITLE
add support for homebrew as pm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
         include:
           - target: darwin-arm64
             runner: [self-hosted, macOS, ARM64]
+          - target: darwin-x64
+            runner: macos-26-intel
           - target: linux-x64
             runner: ubuntu-22.04
           - target: linux-arm64
@@ -89,20 +91,30 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.ref }}
 
+      # the self-hosted mac has its toolchains pre-provisioned
       - uses: pnpm/action-setup@v4
-        if: runner.os == 'Linux'
+        if: matrix.target != 'darwin-arm64'
 
       - uses: actions/setup-node@v4
-        if: runner.os == 'Linux'
+        if: matrix.target != 'darwin-arm64'
         with:
           node-version: 22
 
       - uses: dtolnay/rust-toolchain@stable
-        if: runner.os == 'Linux'
+        if: matrix.target != 'darwin-arm64'
+
+      - run: brew install nasm
+        if: matrix.target == 'darwin-x64'
 
       - run: pnpm install --frozen-lockfile
 
       - name: Build
+        env:
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_P12_PASSWORD: ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: scripts/release.sh "${{ needs.prepare.outputs.version }}" "${{ needs.prepare.outputs.channel }}"
 
       - uses: actions/upload-artifact@v4

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -27,6 +27,7 @@ import type { Direction, Terminal, TerminalCheck } from "pixel-terminals";
 import { actionCommand } from "./action";
 import { control } from "./control";
 import { setupCommand } from "./editors";
+import { ensureSetup, linkSkills, markSetupDone } from "./setup";
 import { commandHelp, helpTopics, rootHelp } from "./help";
 import { browsers, describe, recordKey } from "./instances";
 import type { Browser } from "./instances";
@@ -716,6 +717,7 @@ async function main(): Promise<number> {
     process.stdout.write(commandHelp(command) ?? rootHelp());
     return 0;
   }
+  if (command !== "setup") ensureSetup();
   if (command === "open") {
     await openCommand(args);
     return 0;
@@ -729,7 +731,9 @@ async function main(): Promise<number> {
   }
   if (command === "setup") {
     const sandbox = apparmorSetup(electronBinary());
+    linkSkills();
     const editors = setupCommand();
+    markSetupDone();
     return editors !== 0 ? editors : sandbox;
   }
   if (command === "upgrade") return upgradeCommand();

--- a/cli/src/setup.ts
+++ b/cli/src/setup.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { enableTerminalImages } from "./editors";
+import { installedVersion } from "./upgrade";
+
+interface AgentEntry {
+  name: string;
+  location: string;
+  variant: string;
+}
+
+interface Manifest {
+  agents: AgentEntry[];
+  skills: string[];
+}
+
+function stateDir(): string {
+  const configured = process.env.XDG_STATE_HOME;
+  const base = configured && path.isAbsolute(configured) ? configured : path.join(os.homedir(), ".local", "state");
+  return path.join(base, "terminal-browser");
+}
+
+function distRoot(): string | null {
+  return process.env.TERMINAL_BROWSER_DIST_ROOT ?? null;
+}
+
+function readManifest(root: string): Manifest | null {
+  let lines: string[];
+  try {
+    lines = fs.readFileSync(path.join(root, "skills", "manifest"), "utf8").split("\n");
+  } catch {
+    return null;
+  }
+  const manifest: Manifest = { agents: [], skills: [] };
+  for (const line of lines) {
+    const [kind, ...rest] = line.split(" ").filter(Boolean);
+    if (kind === "agent" && rest.length >= 2) {
+      manifest.agents.push({ name: rest[0], location: rest[1], variant: rest[2] ?? "default" });
+    }
+    if (kind === "skill" && rest[0]) manifest.skills.push(rest[0]);
+  }
+  return manifest;
+}
+
+function isSymlink(file: string): boolean {
+  return fs.lstatSync(file, { throwIfNoEntry: false })?.isSymbolicLink() ?? false;
+}
+
+function exists(file: string): boolean {
+  return fs.lstatSync(file, { throwIfNoEntry: false }) !== undefined;
+}
+
+export interface SkillLinks {
+  linkedAgents: string[];
+  left: string[];
+}
+
+export function linkSkills(): SkillLinks {
+  const result: SkillLinks = { linkedAgents: [], left: [] };
+  const root = distRoot();
+  if (!root) return result;
+  const manifest = readManifest(root);
+  if (!manifest) return result;
+
+  const wrote = new Set<string>();
+  const place = (target: string, link: string): boolean => {
+    if (exists(link) && !isSymlink(link)) {
+      result.left.push(link);
+      return false;
+    }
+    fs.mkdirSync(path.dirname(link), { recursive: true });
+    fs.rmSync(link, { force: true });
+    fs.symlinkSync(target, link);
+    wrote.add(link);
+    return true;
+  };
+
+  for (const agent of manifest.agents) {
+    const dir = path.join(os.homedir(), agent.location);
+    if (!exists(path.dirname(dir))) continue;
+    let made = false;
+    for (const skill of manifest.skills) {
+      const target = path.join(root, "skills", agent.variant, skill);
+      if (!fs.existsSync(target)) continue;
+      if (place(target, path.join(dir, skill))) made = true;
+    }
+    if (made) result.linkedAgents.push(agent.name);
+  }
+
+  const shared = process.env.AGENT_SKILLS_HOME ?? path.join(os.homedir(), ".agents", "skills");
+  for (const skill of manifest.skills) {
+    const target = path.join(root, "skills", "default", skill);
+    if (!fs.existsSync(target)) continue;
+    const link = path.join(shared, skill);
+    if (exists(link) && !isSymlink(link)) {
+      fs.rmSync(path.join(link, "SKILL.md"), { force: true });
+      try {
+        fs.rmdirSync(link);
+      } catch {}
+    }
+    place(target, link);
+  }
+
+  const receiptFile = path.join(stateDir(), "skills.links");
+  let recorded: string[] = [];
+  try {
+    recorded = fs.readFileSync(receiptFile, "utf8").split("\n").filter(Boolean);
+  } catch {}
+  for (const link of recorded) {
+    if (wrote.has(link) || !isSymlink(link)) continue;
+    const target = fs.readlinkSync(link);
+    if (target.startsWith(root + path.sep) || !fs.existsSync(target)) fs.rmSync(link, { force: true });
+  }
+  fs.mkdirSync(stateDir(), { recursive: true });
+  fs.writeFileSync(receiptFile, [...wrote].sort().join("\n") + (wrote.size > 0 ? "\n" : ""));
+  return result;
+}
+
+function marker(): { file: string; want: string } | null {
+  const root = distRoot();
+  const version = installedVersion();
+  if (!root || !version) return null;
+  return { file: path.join(stateDir(), "setup-version"), want: `${version} ${root}` };
+}
+
+export function markSetupDone(): void {
+  const state = marker();
+  if (!state) return;
+  fs.mkdirSync(stateDir(), { recursive: true });
+  fs.writeFileSync(state.file, `${state.want}\n`);
+}
+
+export function ensureSetup(): void {
+  const state = marker();
+  if (!state) return;
+  try {
+    if (fs.readFileSync(state.file, "utf8").trim() === state.want) return;
+  } catch {}
+  try {
+    linkSkills();
+    enableTerminalImages();
+    markSetupDone();
+  } catch {}
+}

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -77,6 +77,11 @@ export async function upgradeCommand(): Promise<number> {
     process.stdout.write(`already up to date (${current})\n`);
     return 0;
   }
+  if (process.env.TERMINAL_BROWSER_DIST_ROOT?.split(path.sep).includes("Caskroom")) {
+    process.stdout.write(`${latest.version} is available. This install is managed by Homebrew, run:\n`);
+    process.stdout.write("  brew upgrade --cask terminal-browser\n");
+    return 0;
+  }
   const open = await instances();
   if (open.length > 0 && process.stdin.isTTY && process.stdout.isTTY) {
     if (!(await confirmClose(latest.version, open))) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "packageManager": "pnpm@10.13.1",
   "devDependencies": {
+    "@electron/osx-sign": "^1.3.3",
     "esbuild": "^0.25.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@electron/osx-sign':
+        specifier: ^1.3.3
+        version: 1.3.3
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
@@ -218,6 +221,11 @@ packages:
   '@electron/get@5.0.0':
     resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
     engines: {node: '>=22.12.0'}
+
+  '@electron/osx-sign@1.3.3':
+    resolution: {integrity: sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -774,6 +782,10 @@ packages:
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
+    engines: {node: '>=14.6'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -795,6 +807,10 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  compare-version@0.1.2:
+    resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
+    engines: {node: '>=0.10.0'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -958,6 +974,10 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -981,8 +1001,15 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  isbinaryfile@4.0.10:
+    resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
+    engines: {node: '>= 8.0.0'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1010,6 +1037,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  plist@3.1.1:
+    resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
+    engines: {node: '>=10.4.0'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -1110,11 +1141,19 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -1148,6 +1187,17 @@ snapshots:
       sumchecker: 3.0.1
     optionalDependencies:
       undici: 7.28.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/osx-sign@1.3.3':
+    dependencies:
+      compare-version: 0.1.2
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      isbinaryfile: 4.0.10
+      minimist: 1.2.8
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -1466,8 +1516,9 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  base64-js@1.5.1:
-    optional: true
+  '@xmldom/xmldom@0.9.12': {}
+
+  base64-js@1.5.1: {}
 
   better-sqlite3@12.11.1:
     dependencies:
@@ -1497,6 +1548,8 @@ snapshots:
 
   chownr@1.1.4:
     optional: true
+
+  compare-version@0.1.2: {}
 
   csstype@3.2.3: {}
 
@@ -1643,6 +1696,12 @@ snapshots:
   fs-constants@1.0.0:
     optional: true
 
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -1664,7 +1723,15 @@ snapshots:
   ini@1.3.8:
     optional: true
 
+  isbinaryfile@4.0.10: {}
+
   js-tokens@4.0.0: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   loose-envify@1.4.0:
     dependencies:
@@ -1673,8 +1740,7 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  minimist@1.2.8:
-    optional: true
+  minimist@1.2.8: {}
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -1693,6 +1759,12 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
     optional: true
+
+  plist@3.1.1:
+    dependencies:
+      '@xmldom/xmldom': 0.9.12
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
 
   prebuild-install@7.1.3:
     dependencies:
@@ -1822,10 +1894,14 @@ snapshots:
   undici@7.28.0:
     optional: true
 
+  universalify@2.0.1: {}
+
   util-deprecate@1.0.2:
     optional: true
 
   wrappy@1.0.2:
     optional: true
+
+  xmlbuilder@15.1.1: {}
 
   zod@4.4.3: {}

--- a/scripts/entitlements.plist
+++ b/scripts/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/fetch-electron.sh
+++ b/scripts/fetch-electron.sh
@@ -7,6 +7,7 @@ DEST="$(node -e 'const p=require("path");console.log(p.join(p.dirname(require.re
 
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64) PLATFORM="darwin-arm64" ;;
+  Darwin-x86_64) PLATFORM="darwin-x64" ;;
   Linux-x86_64) PLATFORM="linux-x64" ;;
   Linux-aarch64) PLATFORM="linux-arm64" ;;
   *) echo "fetch-electron: unsupported platform $(uname -s)-$(uname -m)" >&2; exit 1 ;;

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -6,6 +6,7 @@ OUT="$ROOT/dist-release"
 
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64) TARGET=darwin-arm64 ;;
+  Darwin-x86_64) TARGET=darwin-x64 ;;
   Linux-x86_64|Linux-amd64) TARGET=linux-x64 ;;
   Linux-aarch64|Linux-arm64) TARGET=linux-arm64 ;;
   *) echo "unsupported host: $(uname -s)-$(uname -m)" >&2; exit 1 ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,13 @@ PLATFORMS="__PLATFORMS__"
 
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64) TARGET=darwin-arm64 ;;
+  Darwin-x86_64)
+    if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = 1 ]; then
+      TARGET=darwin-arm64
+    else
+      TARGET=darwin-x64
+    fi
+    ;;
   Linux-x86_64|Linux-amd64) TARGET=linux-x64 ;;
   Linux-aarch64|Linux-arm64) TARGET=linux-arm64 ;;
   *)
@@ -74,70 +81,9 @@ if [ "$(uname -s)" = Linux ]; then
   fi
 fi
 
-AGENT_SKILLS="${AGENT_SKILLS_HOME:-$HOME/.agents/skills}"
-STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
-RECEIPT="$STATE_HOME/terminal-browser/skills.links"
-WROTE="$(mktemp)"
-trap 'rm -rf "$TMP" "$WROTE"' EXIT
-
-link() {
-  mkdir -p "$(dirname "$2")"
-  ln -sfn "$1" "$2"
-  printf '%s\n' "$2" >> "$WROTE"
-}
-
-LINKED=""
-while read -r kind name location variant; do
-  [ "$kind" = agent ] || continue
-  DIR="$HOME/$location"
-  [ -d "$(dirname "$DIR")" ] || continue
-  mkdir -p "$DIR"
-  MADE=""
-  while read -r skind skill; do
-    [ "$skind" = skill ] || continue
-    TARGET="$APP/skills/${variant:-default}/$skill"
-    [ -d "$TARGET" ] || continue
-    LINK="$DIR/$skill"
-    if [ -e "$LINK" ] && [ ! -L "$LINK" ]; then
-      echo "leaving $LINK alone, it is not a link we made"
-      continue
-    fi
-    link "$TARGET" "$LINK"
-    MADE=1
-  done < "$APP/skills/manifest"
-  if [ -n "$MADE" ]; then LINKED="$LINKED $name"; fi
-done < "$APP/skills/manifest"
-
-while read -r kind skill; do
-  [ "$kind" = skill ] || continue
-  [ -d "$APP/skills/default/$skill" ] || continue
-  SHARED="$AGENT_SKILLS/$skill"
-  if [ -d "$SHARED" ] && [ ! -L "$SHARED" ]; then
-    rm -f "$SHARED/SKILL.md"
-    rmdir "$SHARED" 2>/dev/null || true
-  fi
-  if [ -e "$SHARED" ] && [ ! -L "$SHARED" ]; then
-    echo "leaving $SHARED alone, it holds files we did not put there"
-    continue
-  fi
-  link "$APP/skills/default/$skill" "$SHARED"
-done < "$APP/skills/manifest"
-
-if [ -f "$RECEIPT" ]; then
-  while read -r stale; do
-    [ -n "$stale" ] || continue
-    grep -qxF "$stale" "$WROTE" && continue
-    [ -L "$stale" ] || continue
-    case "$(readlink "$stale")" in "$APP"/*) rm -f "$stale"; echo "removed $stale" ;; esac
-  done < "$RECEIPT"
-fi
-mkdir -p "$(dirname "$RECEIPT")"
-sort -u "$WROTE" > "$RECEIPT"
-
 echo "installed terminal-browser $(cat "$APP/VERSION")${CHANNEL:+ ($CHANNEL)}"
-echo "skills $AGENT_SKILLS${LINKED:+ (linked into$LINKED)}"
 
-if [ -z "${TERMINAL_BROWSER_SKIP_EDITOR_SETUP:-}" ]; then
+if [ -z "${TERMINAL_BROWSER_SKIP_SETUP:-}" ]; then
   "$APP/bin/terminal-browser" setup || true
 fi
 case ":$PATH:" in

--- a/scripts/macos-sign.sh
+++ b/scripts/macos-sign.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -euo pipefail
+
+#   MACOS_SIGN_P12           base64 of a .p12 holding a Developer ID Application key
+#   MACOS_SIGN_P12_PASSWORD  password of that .p12
+#   APPLE_API_KEY_P8         App Store Connect API key, PEM text (stable builds)
+#   APPLE_API_KEY_ID         id of that key                     (stable builds)
+#   APPLE_API_ISSUER_ID      issuer id of that key              (stable builds)
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STAGE="${1:?usage: macos-sign.sh <stage-dir> <channel>}"
+CHANNEL="${2:-dev}"
+
+APP="$STAGE/electron/terminal-browser.app"
+LOOSE_BINARIES=(
+  "$STAGE/bin/native-scroll-helper"
+  "$STAGE/agent-browser/bin/agent-browser"
+  "$STAGE/browser/native/pixel.node"
+)
+
+if [ -z "${MACOS_SIGN_P12:-}" ]; then
+  if [ "$CHANNEL" = stable ]; then
+    echo "refusing to sign a stable release ad-hoc: MACOS_SIGN_P12 is not set" >&2
+    exit 1
+  fi
+  for binary in "${LOOSE_BINARIES[@]}"; do
+    codesign --force --sign - --timestamp=none "$binary"
+  done
+  codesign --force --sign - --timestamp=none "$APP"
+  echo "signed ad-hoc (MACOS_SIGN_P12 not set)"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+KEYCHAIN="$WORK/sign.keychain-db"
+KEYCHAIN_PASSWORD="$(uuidgen)"
+ORIGINAL_KEYCHAINS="$(security list-keychains -d user | sed 's/[" ]//g')"
+
+cleanup() {
+  security list-keychains -d user -s $ORIGINAL_KEYCHAINS 2>/dev/null || true
+  security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security set-keychain-settings "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+printf %s "$MACOS_SIGN_P12" | base64 -d > "$WORK/sign.p12"
+security import "$WORK/sign.p12" -k "$KEYCHAIN" -P "${MACOS_SIGN_P12_PASSWORD:-}" -T /usr/bin/codesign
+rm -f "$WORK/sign.p12"
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+security list-keychains -d user -s "$KEYCHAIN" $ORIGINAL_KEYCHAINS
+
+IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" | awk -F'"' '/Developer ID Application/ {print $2; exit}')"
+if [ -z "$IDENTITY" ]; then
+  echo "MACOS_SIGN_P12 holds no Developer ID Application identity" >&2
+  exit 1
+fi
+echo "signing as $IDENTITY"
+
+for binary in "${LOOSE_BINARIES[@]}"; do
+  xattr -c "$binary" 2>/dev/null || true
+  codesign --force --sign "$IDENTITY" --keychain "$KEYCHAIN" --options runtime --timestamp "$binary"
+done
+
+xattr -cr "$APP" 2>/dev/null || true
+node "$ROOT/scripts/sign-app.mjs" "$APP" "$IDENTITY" "$KEYCHAIN" "$ROOT/scripts/entitlements.plist"
+codesign --verify --deep --strict "$APP"
+
+if [ "$CHANNEL" != stable ]; then
+  echo "signed with Developer ID ($CHANNEL build, notarization skipped)"
+  exit 0
+fi
+
+: "${APPLE_API_KEY_P8:?stable release with MACOS_SIGN_P12 also needs APPLE_API_KEY_P8}"
+: "${APPLE_API_KEY_ID:?stable release with MACOS_SIGN_P12 also needs APPLE_API_KEY_ID}"
+: "${APPLE_API_ISSUER_ID:?stable release with MACOS_SIGN_P12 also needs APPLE_API_ISSUER_ID}"
+
+printf %s "$APPLE_API_KEY_P8" > "$WORK/api-key.p8"
+ditto -c -k --keepParent "$STAGE" "$WORK/notarize.zip"
+
+set +e
+SUBMIT_OUTPUT="$(xcrun notarytool submit "$WORK/notarize.zip" \
+  --key "$WORK/api-key.p8" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID" \
+  --wait 2>&1)"
+SUBMIT_STATUS=$?
+set -e
+echo "$SUBMIT_OUTPUT"
+
+if [ $SUBMIT_STATUS -ne 0 ] || ! echo "$SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
+  SUBMISSION_ID="$(echo "$SUBMIT_OUTPUT" | awk '/^[[:space:]]*id: / {print $2; exit}')"
+  if [ -n "$SUBMISSION_ID" ]; then
+    xcrun notarytool log "$SUBMISSION_ID" \
+      --key "$WORK/api-key.p8" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID" || true
+  fi
+  echo "notarization failed" >&2
+  exit 1
+fi
+
+xcrun stapler staple "$APP"
+xcrun stapler validate "$APP"
+echo "signed, notarized and stapled"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,9 +8,10 @@ OUT="$ROOT/dist-release"
 STAGE="$OUT/terminal-browser"
 
 case "$(uname -s)-$(uname -m)" in
-  Darwin-arm64) TARGET=darwin-arm64 ;;
-  Linux-x86_64|Linux-amd64) TARGET=linux-x64 ;;
-  Linux-aarch64|Linux-arm64) TARGET=linux-arm64 ;;
+  Darwin-arm64) TARGET=darwin-arm64; DARWIN_ARCH=arm64 ;;
+  Darwin-x86_64) TARGET=darwin-x64; DARWIN_ARCH=x86_64 ;;
+  Linux-x86_64|Linux-amd64) TARGET=linux-x64; DARWIN_ARCH= ;;
+  Linux-aarch64|Linux-arm64) TARGET=linux-arm64; DARWIN_ARCH= ;;
   *) echo "unsupported build host: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
 esac
 
@@ -18,7 +19,7 @@ rm -rf "$OUT"
 mkdir -p "$STAGE"/{bin,cli/dist,browser/dist,browser/native,electron,agent-browser/bin,assets/fonts,scripts}
 
 (cd "$ROOT/engine" && cargo build -p pixel-node --release)
-if [ "$TARGET" = darwin-arm64 ]; then
+if [ -n "$DARWIN_ARCH" ]; then
   NATIVE_LIB=libpixel_node.dylib
 else
   NATIVE_LIB=libpixel_node.so
@@ -26,17 +27,13 @@ fi
 cp "${CARGO_TARGET_DIR:-$ROOT/engine/target}/release/$NATIVE_LIB" "$STAGE/browser/native/pixel.node"
 
 # the engine bakes in a path to its build directory, which only exists on this machine
-if [ "$TARGET" = darwin-arm64 ]; then
-  swiftc -O -target arm64-apple-macos11 "$ROOT/engine/crates/pixel-core/native-scroll-helper.swift" \
+if [ -n "$DARWIN_ARCH" ]; then
+  swiftc -O -target "$DARWIN_ARCH-apple-macos11" "$ROOT/engine/crates/pixel-core/native-scroll-helper.swift" \
     -o "$STAGE/bin/native-scroll-helper"
-  codesign --force --sign - --timestamp=none "$STAGE/bin/native-scroll-helper" 2>/dev/null || true
 fi
 
 AGENT_BROWSER_BIN="$("$ROOT/scripts/agent-browser.sh" --path)"
 cp "$AGENT_BROWSER_BIN" "$STAGE/agent-browser/bin/agent-browser"
-if [ "$TARGET" = darwin-arm64 ]; then
-  codesign --force --sign - --timestamp=none "$STAGE/agent-browser/bin/agent-browser" 2>/dev/null || true
-fi
 
 "$ROOT/scripts/bundle.sh" "$ROOT/cli/src/main.ts" "$STAGE/cli/dist/main.js"
 "$ROOT/scripts/bundle.sh" "$ROOT/browser/src/main.tsx" "$STAGE/browser/dist/main.js"
@@ -53,7 +50,7 @@ if [ ! -f "$ELECTRON_DIST/.zenbu-electron-sha256" ]; then
   echo "refusing to build: installed electron does not come from https://github.com/zenbu-labs/electron-releases" >&2
   exit 1
 fi
-if [ "$TARGET" = darwin-arm64 ]; then
+if [ -n "$DARWIN_ARCH" ]; then
   APP="$STAGE/electron/terminal-browser.app"
   ditto "$ELECTRON_DIST/Electron.app" "$APP"
   mv "$APP/Contents/MacOS/Electron" "$APP/Contents/MacOS/terminal-browser"
@@ -62,8 +59,8 @@ if [ "$TARGET" = darwin-arm64 ]; then
     -c "Set :CFBundleName terminal-browser" \
     -c "Set :CFBundleDisplayName terminal-browser" \
     -c "Set :CFBundleIdentifier dev.zenbu.terminal-browser" \
+    -c "Add :LSUIElement bool true" \
     "$APP/Contents/Info.plist" >/dev/null
-  codesign --force --sign - --timestamp=none "$APP" 2>/dev/null
   ELECTRON_EXE="electron/terminal-browser.app/Contents/MacOS/terminal-browser"
   NATIVE_SCROLL='export NATIVE_SCROLL_HELPER="${NATIVE_SCROLL_HELPER:-$ROOT/bin/native-scroll-helper}"'
 else
@@ -74,7 +71,15 @@ fi
 
 cat > "$STAGE/bin/terminal-browser" <<EOF
 #!/bin/sh
-ROOT="\$(CDPATH= cd -- "\$(dirname -- "\$0")/.." && pwd -P)"
+SELF="\$0"
+while [ -L "\$SELF" ]; do
+  LINK="\$(readlink "\$SELF")"
+  case "\$LINK" in
+    /*) SELF="\$LINK" ;;
+    *) SELF="\$(dirname -- "\$SELF")/\$LINK" ;;
+  esac
+done
+ROOT="\$(CDPATH= cd -- "\$(dirname -- "\$SELF")/.." && pwd -P)"
 export TERMINAL_BROWSER_DIST_ROOT="\$ROOT"
 export ELECTRON_RUN_AS_NODE=1
 $NATIVE_SCROLL
@@ -84,10 +89,14 @@ chmod +x "$STAGE/bin/terminal-browser"
 echo "$VERSION" > "$STAGE/VERSION"
 echo "$CHANNEL" > "$STAGE/CHANNEL"
 
+if [ -n "$DARWIN_ARCH" ]; then
+  "$ROOT/scripts/macos-sign.sh" "$STAGE" "$CHANNEL"
+fi
+
 TARBALL="$OUT/terminal-browser-$TARGET.tar.gz"
 tar -czf "$TARBALL" -C "$OUT" terminal-browser
 
-if [ "$TARGET" = darwin-arm64 ]; then
+if [ -n "$DARWIN_ARCH" ]; then
   SHA256="$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)"
   SIZE="$(stat -f%z "$TARBALL")"
 else

--- a/scripts/render-cask.mjs
+++ b/scripts/render-cask.mjs
@@ -43,11 +43,10 @@ process.stdout.write(`cask "terminal-browser" do
          arm64_linux:  "${sha("linux-arm64")}",
          x86_64_linux: "${sha("linux-x64")}"
 
-  url "https://terminal-browser.sh/install/dl/stable/v#{version}/terminal-browser-#{os}-#{arch}.tar.gz",
-      verified: "terminal-browser.sh/install/dl/"
+  url "https://terminal-browser.sh/install/dl/stable/v#{version}/terminal-browser-#{os}-#{arch}.tar.gz"
   name "terminal-browser"
-  desc "A browser inside your terminal"
-  homepage "https://github.com/zenbu-labs/terminal-browser"
+  desc "Terminal-based web browser"
+  homepage "https://terminal-browser.sh"
 
   livecheck do
     url "https://terminal-browser.sh/install/latest.json"
@@ -57,8 +56,6 @@ process.stdout.write(`cask "terminal-browser" do
   end
 
   binary "terminal-browser/bin/terminal-browser"
-
-  caveats "run terminal-browser setup to configure agent skills"
 
   zap trash: [
     "~/.agents/skills/terminal-browser",

--- a/scripts/render-cask.mjs
+++ b/scripts/render-cask.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const dir = process.argv[2] ?? "dist-release";
+const manifests = fs
+  .readdirSync(dir)
+  .filter((file) => /^manifest-[a-z0-9-]+\.json$/.test(file))
+  .map((file) => JSON.parse(fs.readFileSync(path.join(dir, file), "utf8")));
+
+const byPlatform = Object.fromEntries(manifests.map((m) => [m.platform, m]));
+const required = ["darwin-arm64", "darwin-x64", "linux-x64", "linux-arm64"];
+const missing = required.filter((platform) => !byPlatform[platform]);
+if (missing.length) {
+  console.error(`missing manifests in ${dir} for: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+const [first, ...rest] = manifests;
+for (const manifest of rest) {
+  if (manifest.version !== first.version || manifest.channel !== first.channel) {
+    console.error(
+      `manifest mismatch: ${manifest.platform} is ${manifest.channel}/${manifest.version}, ` +
+        `expected ${first.channel}/${first.version}`,
+    );
+    process.exit(1);
+  }
+}
+if (first.channel !== "stable") {
+  console.error(`refusing to render a cask for the ${first.channel} channel`);
+  process.exit(1);
+}
+
+const version = first.version.replace(/^v/, "");
+const sha = (platform) => byPlatform[platform].sha256;
+
+process.stdout.write(`cask "terminal-browser" do
+  arch arm: "arm64", intel: "x64"
+  os macos: "darwin", linux: "linux"
+
+  version "${version}"
+  sha256 arm:          "${sha("darwin-arm64")}",
+         intel:        "${sha("darwin-x64")}",
+         arm64_linux:  "${sha("linux-arm64")}",
+         x86_64_linux: "${sha("linux-x64")}"
+
+  url "https://terminal-browser.sh/install/dl/stable/v#{version}/terminal-browser-#{os}-#{arch}.tar.gz",
+      verified: "terminal-browser.sh/install/dl/"
+  name "terminal-browser"
+  desc "A browser inside your terminal"
+  homepage "https://github.com/zenbu-labs/terminal-browser"
+
+  livecheck do
+    url "https://terminal-browser.sh/install/latest.json"
+    strategy :json do |json|
+      json["version"]&.delete_prefix("v")
+    end
+  end
+
+  binary "terminal-browser/bin/terminal-browser"
+
+  caveats "run terminal-browser setup to configure agent skills"
+
+  zap trash: [
+    "~/.agents/skills/terminal-browser",
+    "~/.cache/terminal-browser-*",
+    "~/.claude/skills/terminal-browser",
+    "~/.codex/skills/terminal-browser",
+    "~/.cursor/skills/terminal-browser",
+    "~/.gemini/skills/terminal-browser",
+    "~/.local/share/terminal-browser-*",
+    "~/.local/state/terminal-browser",
+    "~/.local/state/terminal-browser-*",
+  ]
+end
+`);

--- a/scripts/sign-app.mjs
+++ b/scripts/sign-app.mjs
@@ -1,0 +1,14 @@
+import { signAsync } from "@electron/osx-sign";
+
+const [app, identity, keychain, entitlements] = process.argv.slice(2);
+if (!entitlements) {
+  console.error("usage: sign-app.mjs <app> <identity> <keychain> <entitlements>");
+  process.exit(1);
+}
+
+await signAsync({
+  app,
+  identity,
+  keychain,
+  optionsForFile: () => ({ entitlements, hardenedRuntime: true }),
+});

--- a/store/src/paths.ts
+++ b/store/src/paths.ts
@@ -36,7 +36,11 @@ function physical(dir: string): string {
 
 export const INSTALL_ROOT = installRoot();
 
-const suffix = crypto.createHash("sha256").update(INSTALL_ROOT.root).digest("hex").slice(0, 8);
+function stableIdentity(root: string): string {
+  return root.replace(/([/\\]Caskroom[/\\]terminal-browser[/\\])[^/\\]+/, "$1");
+}
+
+const suffix = crypto.createHash("sha256").update(stableIdentity(INSTALL_ROOT.root)).digest("hex").slice(0, 8);
 
 export const APP_DIR_NAME = `terminal-browser${INSTALL_ROOT.dev ? "-dev" : ""}-${suffix}`;
 


### PR DESCRIPTION
Adds configurations necessary for publishing terminal-browser through homebrew.

- homebrew does not allow a "postinstall" script, which we need to configure agent skills and enable image rendering in vscode. The only option here is to setup configuration on the first time terminal-browser is ran, which is fine but has cases its a downgrade in experience. This is implemented by running the same setup script that would be ran on postinstall of the curl bash installer on the first run, such that if not setup it sets up
- we also update terminal-browser to support macos x86-64 since we're already touching this logic and there was no reason we weren't before (paired with a new published build for pixel electron https://github.com/zenbu-labs/pixel-electron/commit/cf844a6b7961ad0ec94161809d6078d7c2ffde65)
- we need notarize all binaries executed by macos at any point, since homebrew adds metadata to these binaries that makes apple not execute them without them being notarized
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->