### PR TITLE
feat: add support for no certificate https website

### DIFF
--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, screen } from "electron";
+import type { Certificate } from "electron";
 import type {
   EngineKeyEvent,
   PastedImage,
@@ -19,7 +20,7 @@ import { offscreenPreferences } from "./offscreen";
 import { BitmapPresenter, presentPaint, shmFrameOf } from "./paint";
 import { PopupWindow } from "./popup";
 import { cssSize, initialBrowserState } from "./types";
-import type { BrowserState, BrowserSurfaceLayout } from "./types";
+import type { BrowserState, BrowserSurfaceLayout, CertificateWarning } from "./types";
 import { scaleZoom, stepZoom } from "./zoom";
 import type { ZoomDirection } from "./zoom";
 
@@ -50,6 +51,9 @@ export class BrowserController {
   private emitHandlers = new Map<string, (data: unknown) => void>();
   private cdpEventHandlers = new Map<string, (params: unknown) => void>();
   private framePinned = false;
+  private certificateWarningValue: CertificateWarning | null = null;
+  private certificateSafeUrl = "";
+  private readonly trustedCertificates = new Set<string>();
   private readonly onDisplayChange = () => {
     if (this.stopped) return;
     this.applyFrameRate();
@@ -209,6 +213,7 @@ export class BrowserController {
       this.handleWindowOpen(details, this.window.webContents),
     );
     this.window.webContents.on("did-create-window", (child) => this.adoptPopup(child));
+    this.window.webContents.on("certificate-error", this.onCertificateError);
     void this.window.loadURL(normalizeUrl(initialUrl, cwd));
     this.onState(this.state);
   }
@@ -233,10 +238,16 @@ export class BrowserController {
   }
 
   navigate(value: string) {
+    this.certificateWarningValue = null;
+    this.certificateSafeUrl = "";
     void this.window.webContents.loadURL(normalizeUrl(value, this.cwd));
   }
 
   back() {
+    if (this.certificateWarningValue) {
+      this.leaveCertificateWarning();
+      return;
+    }
     if (this.window.webContents.navigationHistory.canGoBack()) {
       this.window.webContents.navigationHistory.goBack();
     }
@@ -249,8 +260,43 @@ export class BrowserController {
   }
 
   reload() {
-    if (this.state.loading) this.window.webContents.stop();
-    else this.window.webContents.reload();
+    if (this.state.loading) {
+      this.window.webContents.stop();
+    } else if (this.certificateWarningValue) {
+      const url = this.certificateWarningValue.url;
+      this.certificateWarningValue = null;
+      this.certificateSafeUrl = "";
+      void this.window.webContents.loadURL(url);
+    } else {
+      this.window.webContents.reload();
+    }
+  }
+
+  get certificateWarning(): CertificateWarning | null {
+    return this.certificateWarningValue;
+  }
+
+  trustCertificate() {
+    const warning = this.certificateWarningValue;
+    if (!warning) return;
+    this.trustedCertificates.add(certificateKey(warning.url, warning.fingerprint));
+    this.certificateWarningValue = null;
+    this.updateState({ loading: true, favicon: null });
+    void this.window.webContents.loadURL(warning.url);
+  }
+
+  leaveCertificateWarning() {
+    const warning = this.certificateWarningValue;
+    if (!warning) return;
+    const safeUrl = this.certificateSafeUrl;
+    this.certificateWarningValue = null;
+    this.certificateSafeUrl = "";
+    if (safeUrl && safeUrl !== "about:blank" && safeUrl !== warning.url) {
+      this.updateNavigation(false, safeUrl);
+      this.window.webContents.invalidate();
+    } else {
+      void this.window.webContents.loadURL("about:blank");
+    }
   }
 
   zoom(direction: ZoomDirection): number {
@@ -520,6 +566,35 @@ export class BrowserController {
     this.onClosed?.();
   };
 
+  private readonly onCertificateError = (
+    event: Electron.Event,
+    url: string,
+    error: string,
+    certificate: Certificate,
+    callback: (isTrusted: boolean) => void,
+    isMainFrame: boolean,
+  ) => {
+    const key = certificateKey(url, certificate.fingerprint);
+    if (this.trustedCertificates.has(key)) {
+      event.preventDefault();
+      callback(true);
+      return;
+    }
+    callback(false);
+    if (!isMainFrame) return;
+    this.certificateSafeUrl = this.window.webContents.getURL();
+    this.certificateWarningValue = {
+      url,
+      error,
+      subject: certificate.subjectName,
+      issuer: certificate.issuerName,
+      fingerprint: certificate.fingerprint,
+      validStart: certificate.validStart,
+      validExpiry: certificate.validExpiry,
+    };
+    this.updateState({ url, loading: false, favicon: null });
+  };
+
   setVisible(visible: boolean) {
     if (this.stopped) return;
     if (this.visible === visible) return;
@@ -553,8 +628,9 @@ export class BrowserController {
   }
 
   private updateNavigation(loading: boolean, url = this.window.webContents.getURL()) {
+    const visibleUrl = this.certificateWarningValue?.url ?? url;
     this.updateState({
-      url,
+      url: visibleUrl,
       loading,
       canGoBack: this.window.webContents.navigationHistory.canGoBack(),
       canGoForward: this.window.webContents.navigationHistory.canGoForward(),
@@ -675,6 +751,14 @@ export class BrowserController {
   }
 }
 
+function certificateKey(url: string, fingerprint: string): string {
+  try {
+    return `${new URL(url).origin}\n${fingerprint}`;
+  } catch {
+    return `${url}\n${fingerprint}`;
+  }
+}
+
 function browserRenderScale(layout: BrowserSurfaceLayout) {
   const explicit = Number(process.env.TERMINAL_BROWSER_RENDER_SCALE);
   if (Number.isFinite(explicit) && explicit > 0) {
@@ -685,4 +769,3 @@ function browserRenderScale(layout: BrowserSurfaceLayout) {
   const cssPixels = layout.width * layout.height / (layout.scale * layout.scale);
   return Math.max(0.5, Math.min(layout.scale, Math.sqrt(maxPixels / cssPixels)));
 }
-

--- a/browser/src/page/types.ts
+++ b/browser/src/page/types.ts
@@ -11,6 +11,16 @@ export interface BrowserState {
   zoom: number;
 }
 
+export interface CertificateWarning {
+  url: string;
+  error: string;
+  subject: string;
+  issuer: string;
+  fingerprint: string;
+  validStart: number;
+  validExpiry: number;
+}
+
 export function initialBrowserState(url: string): BrowserState {
   return {
     url,

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -572,6 +572,7 @@ class Session {
     this.root.render(
       <Chrome
         state={this.tabs.activeState ?? this.fallbackState}
+        certificateWarning={this.tabs.activeController?.certificateWarning ?? null}
         actions={this.actions}
         layout={this.layout}
         colors={this.root.info.colors}
@@ -618,6 +619,8 @@ class Session {
       this.activeRecord()?.reloaded();
       this.tabs.activeController?.reload();
     },
+    certificateBack: () => this.tabs.activeController?.leaveCertificateWarning(),
+    certificateProceed: () => this.tabs.activeController?.trustCertificate(),
     urlEdit: () => this.openUrlEdit(),
     urlEditCancel: () => this.closeUrlEdit(),
     urlSubmit: (text) => {
@@ -1508,4 +1511,3 @@ function rememberUrl(url: string) {
     setLastUrl(url);
   } catch { }
 }
-

--- a/browser/src/ui/chrome.tsx
+++ b/browser/src/ui/chrome.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Box, Text } from "pixel-react";
 import type { EngineInfo, Surface } from "pixel-react";
 import type { BrowserState } from "../page/types";
+import type { CertificateWarning } from "../page/types";
 import { Icon } from "./icons";
 import type { IconName } from "./icons";
 import { PageContextMenu } from "./context-menu";
@@ -16,7 +17,7 @@ import {
   ReviewToolbar,
 } from "./record-bar";
 import { TabStrip } from "./tab-strip";
-import { makeTheme } from "./theme";
+import { makeTheme, mix } from "./theme";
 import type { Theme } from "./theme";
 import type { RecordView } from "../record/types";
 import type {
@@ -32,6 +33,7 @@ import type {
 
 export function Chrome({
   state,
+  certificateWarning,
   actions,
   layout,
   colors,
@@ -54,6 +56,7 @@ export function Chrome({
   devtoolsSurface,
 }: {
   state: BrowserState;
+  certificateWarning: CertificateWarning | null;
   actions: ChromeActions;
   layout: ChromeLayout;
   colors: EngineInfo["colors"];
@@ -107,6 +110,7 @@ export function Chrome({
         surface={pageSurface}
         actions={actions}
         interactive={!record?.canvas}
+        certificateWarning={certificateWarning}
       />
       {layout.devtools && (
         <DevtoolsPane
@@ -235,12 +239,14 @@ function BrowserTabContents({
   surface,
   actions,
   interactive,
+  certificateWarning,
 }: {
   layout: ChromeLayout;
   theme: Theme;
   surface: Surface;
   actions: ChromeActions;
   interactive: boolean;
+  certificateWarning: CertificateWarning | null;
 }) {
   const dock = layout.devtools?.dock ?? null;
   return (
@@ -257,26 +263,210 @@ function BrowserTabContents({
           }}
         />
       )}
-      <Box
-        id="browser-surface"
-        surface={surface}
-        style={{
-          position: "absolute",
-          inset: { top: layout.page.y, left: layout.page.x },
-          width: layout.page.width,
-          height: layout.page.height,
-          cornerRadius: layout.frame
-            ? seamRadius(Math.max(2, layout.rem * 0.55 - 1), dock, "page")
-            : 0,
-          background: theme.bg,
-        }}
-        onPointer={interactive ? actions.pointer : undefined}
-        onWheel={interactive ? actions.wheel : undefined}
-        onMouseEnter={() => actions.pageHover(true)}
-        onMouseLeave={() => actions.pageHover(false)}
-      />
+      {certificateWarning ? (
+        <CertificateWarningPage
+          key={`${certificateWarning.url}:${certificateWarning.fingerprint}`}
+          warning={certificateWarning}
+          layout={layout}
+          theme={theme}
+          actions={actions}
+        />
+      ) : (
+        <Box
+          id="browser-surface"
+          surface={surface}
+          style={{
+            position: "absolute",
+            inset: { top: layout.page.y, left: layout.page.x },
+            width: layout.page.width,
+            height: layout.page.height,
+            cornerRadius: layout.frame
+              ? seamRadius(Math.max(2, layout.rem * 0.55 - 1), dock, "page")
+              : 0,
+            background: theme.bg,
+          }}
+          onPointer={interactive ? actions.pointer : undefined}
+          onWheel={interactive ? actions.wheel : undefined}
+          onMouseEnter={() => actions.pageHover(true)}
+          onMouseLeave={() => actions.pageHover(false)}
+        />
+      )}
     </>
   );
+}
+
+function CertificateWarningPage({
+  warning,
+  layout,
+  theme,
+  actions,
+}: {
+  warning: CertificateWarning;
+  layout: ChromeLayout;
+  theme: Theme;
+  actions: ChromeActions;
+}) {
+  const rem = layout.rem;
+  const host = certificateHost(warning.url);
+  return (
+    <Box
+      id="certificate-warning"
+      style={{
+        position: "absolute",
+        inset: { top: layout.page.y, left: layout.page.x },
+        width: layout.page.width,
+        height: layout.page.height,
+        flexDirection: "column",
+        alignItems: "center",
+        overflow: "scroll",
+        background: theme.bg,
+        padding: {
+          left: rem * 1.5,
+          right: rem * 1.5,
+          top: rem * 2.5,
+          bottom: rem * 2.5,
+        },
+      }}
+    >
+      <Box style={{ width: "100%", maxWidth: rem * 42, flexDirection: "column", gap: rem }}>
+        <Box
+          style={{
+            width: rem * 3.4,
+            height: rem * 3.4,
+            alignItems: "center",
+            justifyContent: "center",
+            cornerRadius: rem * 1.7,
+            background: mix(theme.bg, theme.red, 0.22),
+            border: { width: 1, color: mix(theme.bg, theme.red, 0.55) },
+          }}
+        >
+          <Text style={{ fontSize: rem * 2.2, color: theme.red, selectable: false }}>!</Text>
+        </Box>
+        <Text
+          style={{ fontSize: rem * 1.75, color: theme.fg, selectable: false }}
+          spans={[{ start: 0, end: 30, color: theme.fg, bold: true }]}
+        >
+          Your connection is not private
+        </Text>
+        <Text style={{ fontSize: rem, color: theme.muted }}>
+          {`The identity of ${host} could not be verified. Attackers might be trying to steal information you send to this site.`}
+        </Text>
+        <Text style={{ fontSize: rem * 0.82, color: theme.disabled }}>
+          {certificateErrorLabel(warning.error)}
+        </Text>
+        <Box style={{ flexDirection: "column", gap: rem * 0.55, padding: { top: rem * 0.4 } }}>
+          <CertificateButton
+            label="Back to safety"
+            primary
+            rem={rem}
+            theme={theme}
+            onClick={actions.certificateBack}
+          />
+          <CertificateButton
+            label={`Continue to ${host} (unsafe)`}
+            rem={rem}
+            theme={theme}
+            onClick={actions.certificateProceed}
+          />
+        </Box>
+        <Box
+          style={{
+            flexDirection: "column",
+            gap: rem * 0.35,
+            margin: { top: rem * 0.6 },
+            padding: rem,
+            cornerRadius: rem * 0.4,
+            background: theme.field,
+            border: { width: 1, color: theme.fieldBorder },
+          }}
+        >
+          <CertificateDetail label="Subject" value={warning.subject || "Unknown"} rem={rem} theme={theme} />
+          <CertificateDetail label="Issuer" value={warning.issuer || "Unknown"} rem={rem} theme={theme} />
+          <CertificateDetail
+            label="Valid"
+            value={`${certificateDate(warning.validStart)} – ${certificateDate(warning.validExpiry)}`}
+            rem={rem}
+            theme={theme}
+          />
+          <CertificateDetail
+            label="Fingerprint"
+            value={warning.fingerprint || "Unavailable"}
+            rem={rem}
+            theme={theme}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function CertificateButton({
+  label,
+  primary = false,
+  rem,
+  theme,
+  onClick,
+}: {
+  label: string;
+  primary?: boolean;
+  rem: number;
+  theme: Theme;
+  onClick(): void;
+}) {
+  return (
+    <Box
+      style={{
+        alignItems: "center",
+        justifyContent: "center",
+        padding: { left: rem, right: rem, top: rem * 0.55, bottom: rem * 0.55 },
+        cornerRadius: rem * 0.35,
+        background: primary ? theme.accent : theme.field,
+        hoverBackground: primary ? mix(theme.accent, theme.fg, 0.18) : theme.hoverStrong,
+        border: primary ? undefined : { width: 1, color: theme.fieldBorder },
+      }}
+      onClick={onClick}
+    >
+      <Text style={{ color: primary ? theme.bg : theme.fg, wrap: false, selectable: false }}>
+        {label}
+      </Text>
+    </Box>
+  );
+}
+
+function CertificateDetail({
+  label,
+  value,
+  rem,
+  theme,
+}: {
+  label: string;
+  value: string;
+  rem: number;
+  theme: Theme;
+}) {
+  return (
+    <Box style={{ flexDirection: "column", gap: rem * 0.12 }}>
+      <Text style={{ fontSize: rem * 0.72, color: theme.disabled, selectable: false }}>{label}</Text>
+      <Text style={{ fontSize: rem * 0.82, color: theme.muted }}>{value}</Text>
+    </Box>
+  );
+}
+
+function certificateHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+function certificateErrorLabel(error: string): string {
+  return error.toUpperCase();
+}
+
+function certificateDate(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "Unknown";
+  return new Date(seconds * 1000).toLocaleDateString();
 }
 
 const DIVIDER_ACTIVE = [58, 96, 168, 255] as const;
@@ -395,4 +585,3 @@ function ToolbarButton({
     </Box>
   );
 }
-

--- a/browser/src/ui/types.ts
+++ b/browser/src/ui/types.ts
@@ -52,6 +52,8 @@ export interface ChromeActions {
   back(): void;
   forward(): void;
   reload(): void;
+  certificateBack(): void;
+  certificateProceed(): void;
   urlEdit(): void;
   urlEditCancel(): void;
   urlSubmit(text: string): void;


### PR DESCRIPTION
## Motivation

I often use SSH to log into my home server for development and access internal web pages via terminal-browser. However, some of these internal pages use HTTPS. Previously, the terminal-browser did not handle errors related to untrusted certificates—such as allowing the user to manually confirm and proceed—in the way Chrome does. I have now added this functionality.

## Description

When Electron emits a certificate-error event for a main-frame navigation, the request is rejected and an interstitial displays the error and certificate details. Users can return to the previous safe page or explicitly continue. Trust is scoped to the current tab, origin, and certificate fingerprint; continuing retries the navigation and accepts only the matching certificate. 

## Example

<img width="782" height="559" alt="image" src="https://github.com/user-attachments/assets/047a0815-da61-4dea-be59-c8cdf0bff2ad" />
