### PR TITLE
terminal-browser app interop

### DIFF
--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -23,6 +23,17 @@ import type { BrowserState, BrowserSurfaceLayout } from "./types";
 import { scaleZoom, stepZoom } from "./zoom";
 import type { ZoomDirection } from "./zoom";
 
+export interface ControllerOptions {
+  cwd: string;
+  background: string;
+  visible: boolean;
+  partition: string | null;
+  tabsAsPopups: boolean;
+  clipboardRead: boolean;
+  sessionKey: string;
+  appTabId: number | null;
+}
+
 export class BrowserController {
   readonly surface: Surface;
   private readonly popupSurface: Surface;
@@ -39,6 +50,7 @@ export class BrowserController {
   private readonly tabsAsPopups: boolean;
   private readonly clipboardRead: boolean;
   private readonly sessionKey: string;
+  private readonly appTabId: number | null;
   private readonly cwd: string;
   private background: string;
   private pendingPopupSize: { width: number; height: number } | null = null;
@@ -80,26 +92,21 @@ export class BrowserController {
     devtoolsSurface: Surface,
     layout: BrowserSurfaceLayout,
     initialUrl: string,
-    cwd: string,
-    background: string,
-    visible: boolean,
-    partition: string | null,
-    tabsAsPopups: boolean,
-    clipboardRead: boolean,
-    sessionKey: string,
+    options: ControllerOptions,
     onState: (state: BrowserState) => void,
   ) {
-    this.partition = partition ? persistentPartition(partition) : null;
-    this.tabsAsPopups = tabsAsPopups;
-    this.clipboardRead = clipboardRead;
-    this.sessionKey = sessionKey;
-    this.cwd = cwd;
+    this.partition = options.partition ? persistentPartition(options.partition) : null;
+    this.tabsAsPopups = options.tabsAsPopups;
+    this.clipboardRead = options.clipboardRead;
+    this.sessionKey = options.sessionKey;
+    this.appTabId = options.appTabId;
+    this.cwd = options.cwd;
     this.surface = surface;
     this.bitmaps = new BitmapPresenter(surface);
     this.popupSurface = popupSurface;
     this.devtoolsSurface = devtoolsSurface;
-    this.background = background;
-    this.visible = visible;
+    this.background = options.background;
+    this.visible = options.visible;
     this.layout = layout;
     this.onState = onState;
     this.renderScale = browserRenderScale(layout);
@@ -126,10 +133,10 @@ export class BrowserController {
         contextIsolation: true,
         disableDialogs: true,
         backgroundThrottling: false,
-        additionalArguments: [`--terminal-browser-session=${this.sessionKey}`],
+        additionalArguments: this.preloadArgv(),
       },
     });
-    if (clipboardRead) allowClipboardRead(this.window.webContents);
+    if (this.clipboardRead) allowClipboardRead(this.window.webContents);
     this.input = new PageInput({
       contents: () => this.window.webContents,
       scale: () => this.layout.scale,
@@ -209,7 +216,7 @@ export class BrowserController {
       this.handleWindowOpen(details, this.window.webContents),
     );
     this.window.webContents.on("did-create-window", (child) => this.adoptPopup(child));
-    void this.window.loadURL(normalizeUrl(initialUrl, cwd));
+    void this.window.loadURL(normalizeUrl(initialUrl, this.cwd));
     this.onState(this.state);
   }
 
@@ -530,6 +537,12 @@ export class BrowserController {
     if (visible) this.window.webContents.invalidate();
   }
 
+  private preloadArgv(): string[] {
+    const argv = [`--terminal-browser-session=${this.sessionKey}`];
+    if (this.appTabId != null) argv.push(`--terminal-browser-app-tab=${this.appTabId}`);
+    return argv;
+  }
+
   private contentSize(layout: BrowserSurfaceLayout) {
     return cssSize(layout.width, layout.height, layout.scale);
   }
@@ -608,7 +621,7 @@ export class BrowserController {
             contextIsolation: true,
             disableDialogs: true,
             backgroundThrottling: false,
-            additionalArguments: [`--terminal-browser-session=${this.sessionKey}`],
+            additionalArguments: this.preloadArgv(),
           },
         },
       };

--- a/browser/src/registry.ts
+++ b/browser/src/registry.ts
@@ -3,8 +3,15 @@ import net from "node:net";
 import path from "node:path";
 
 import { callerTty } from "pixel-terminals";
-import { removeInstance, upsertInstance } from "pixel-store";
-import type { InstanceRow } from "pixel-store";
+import {
+  INTEROP_PROTOCOL_VERSIONS,
+  advertiseInstance,
+  openSpecSchema,
+  removeInstance,
+  upsertInstance,
+  withdrawInstance,
+} from "pixel-store";
+import type { InstanceRow, OpenResult, OpenSpec } from "pixel-store";
 
 import type { BrowserState } from "./page/types";
 import { INSTANCES_DIR } from "pixel-store";
@@ -15,6 +22,10 @@ export interface Where {
   pane: string | null;
 }
 
+export interface InteropInfo {
+  mode: "browser" | "app";
+}
+
 export interface ControlHost {
   key: string;
   tty: string | null;
@@ -22,15 +33,19 @@ export interface ControlHost {
   splitDir: InstanceRow["splitDir"];
   parentTty: string | null;
   state(): BrowserState;
+  interop(): InteropInfo;
+  openAppTab(spec: OpenSpec, app: NonNullable<OpenSpec["app"]>): OpenResult;
   openTab(url?: string, cwd?: string): number;
   activateTab(id: number): boolean;
   closeTab(id: number): boolean;
+  hasTab(id: number): boolean;
   tabs(): unknown;
   targets(): Promise<unknown>;
   viewport(): { width: number; height: number } | null;
 }
 
 interface ControlRequest {
+  id?: string;
   cmd: string;
   url?: string;
   cwd?: string;
@@ -39,12 +54,13 @@ interface ControlRequest {
 
 export class Registry {
   private readonly host: ControlHost;
-  private readonly socketPath: string;
+  readonly socketPath: string;
   private readonly tty: string | null;
   private readonly startedAt = Date.now();
   private cdpPort: number | null = null;
   private server: net.Server | null = null;
   private disposed = false;
+  private readonly watchers = new Map<net.Socket, { tab: number; id: string }>();
 
   constructor(host: ControlHost) {
     this.host = host;
@@ -56,6 +72,7 @@ export class Registry {
     this.server.on("error", () => {});
     this.server.listen(this.socketPath);
     this.write();
+    this.advertise();
   }
 
   setCdpPort(port: number | null) {
@@ -65,6 +82,7 @@ export class Registry {
 
   update() {
     this.write();
+    this.sweepWatchers("closed");
   }
 
   record(): InstanceRow {
@@ -86,9 +104,18 @@ export class Registry {
   dispose() {
     if (this.disposed) return;
     this.disposed = true;
+    for (const [connection, watched] of [...this.watchers]) {
+      this.watchers.delete(connection);
+      try {
+        connection.end(
+          `${JSON.stringify({ id: watched.id, event: "app-closed", tab: watched.tab, reason: "shutdown" })}\n`,
+        );
+      } catch {}
+    }
     this.server?.close();
     this.server = null;
     void removeInstance(this.host.key).catch(() => {});
+    withdrawInstance(this.host.key);
     fs.rmSync(this.socketPath, { force: true });
   }
 
@@ -97,29 +124,81 @@ export class Registry {
     void upsertInstance(this.record()).catch(() => {});
   }
 
+  private advertise() {
+    advertiseInstance(this.host.key, {
+      protocolVersions: INTEROP_PROTOCOL_VERSIONS,
+      mode: this.host.interop().mode,
+      pid: process.pid,
+      socket: this.socketPath,
+      startedAt: this.startedAt,
+    });
+  }
+
+  private sweepWatchers(reason: string) {
+    for (const [connection, watched] of [...this.watchers]) {
+      if (this.host.hasTab(watched.tab)) continue;
+      this.watchers.delete(connection);
+      try {
+        connection.end(
+          `${JSON.stringify({ id: watched.id, event: "app-closed", tab: watched.tab, reason })}\n`,
+        );
+      } catch {}
+    }
+  }
+
   private serve(connection: net.Socket) {
     let buffer = "";
     connection.setEncoding("utf8");
     connection.on("error", () => {});
+    connection.on("close", () => {
+      const watched = this.watchers.get(connection);
+      if (watched === undefined) return;
+      this.watchers.delete(connection);
+      if (this.host.hasTab(watched.tab)) this.host.closeTab(watched.tab);
+    });
     connection.on("data", (chunk: string) => {
       buffer += chunk;
-      const newline = buffer.indexOf("\n");
-      if (newline < 0) return;
-      const line = buffer.slice(0, newline);
-      buffer = "";
-      void this.handle(line)
-        .then((data) => {
-          connection.end(`${JSON.stringify({ ok: true, data })}\n`);
-        })
-        .catch((error: unknown) => {
-          const message = error instanceof Error ? error.message : String(error);
-          connection.end(`${JSON.stringify({ ok: false, error: message })}\n`);
-        });
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        newline = buffer.indexOf("\n");
+        if (line.trim()) void this.dispatch(line, connection);
+      }
     });
   }
 
-  private async handle(line: string): Promise<unknown> {
-    const request = JSON.parse(line) as ControlRequest;
+  private async dispatch(line: string, connection: net.Socket) {
+    let id: string | null = null;
+    try {
+      const request = JSON.parse(line) as ControlRequest;
+      id = typeof request.id === "string" && request.id.length > 0 ? request.id : null;
+      if (id === null) throw new Error("request id required");
+      if (request.cmd === "interop/1/open") {
+        const parsed = openSpecSchema.safeParse(request);
+        if (!parsed.success) throw new Error("malformed open request");
+        const spec = parsed.data;
+        if (!spec.app) {
+          const tab = this.host.openTab(spec.url);
+          connection.end(`${JSON.stringify({ id, ok: true, data: { tab } })}\n`);
+          return;
+        }
+        const result = this.host.openAppTab(spec, spec.app);
+        connection.write(`${JSON.stringify({ id, ok: true, data: result })}\n`);
+        this.watchers.set(connection, { tab: result.tab, id });
+        return;
+      }
+      const data = await this.handle(request);
+      connection.end(`${JSON.stringify({ id, ok: true, data })}\n`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      try {
+        connection.end(`${JSON.stringify({ id, ok: false, error: message })}\n`);
+      } catch {}
+    }
+  }
+
+  private async handle(request: ControlRequest): Promise<unknown> {
     switch (request.cmd) {
       case "state":
         return this.record();

--- a/browser/src/session/fuzzy.ts
+++ b/browser/src/session/fuzzy.ts
@@ -1,0 +1,15 @@
+export function fuzzyScore(query: string, target: string): number {
+  const q = query.trim().toLowerCase();
+  const t = target.toLowerCase();
+  if (!q || !t) return 0;
+  if (t.startsWith(q)) return 3;
+  if (t.split(/[\s-]+/).some((word) => word.startsWith(q))) return 2.5;
+  if (t.includes(q)) return 2;
+  let at = 0;
+  for (const char of q) {
+    at = t.indexOf(char, at);
+    if (at < 0) return 0;
+    at++;
+  }
+  return 1;
+}

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -21,8 +22,14 @@ import { initialBrowserState } from "../page/types";
 import type { BrowserState, BrowserSurfaceLayout } from "../page/types";
 import { zoomDirection } from "../page/zoom";
 import type { ZoomDirection } from "../page/zoom";
-import { lastUrl, setLastUrl, settings, store } from "pixel-store";
-import type { DevtoolsDock, InstanceRow } from "pixel-store";
+import { appId, lastUrl, listApps, setLastUrl, settings, store } from "pixel-store";
+import type {
+  DevtoolsDock,
+  InstanceRow,
+  OpenResult,
+  OpenSpec,
+  RegisteredApp,
+} from "pixel-store";
 
 import { RecordSession } from "../record/session";
 import type { RecordActions } from "../record/types";
@@ -38,12 +45,15 @@ import type {
   PopupView,
 } from "../ui/types";
 import { normalizeUrl, searchOrUrl } from "../url";
+import { fuzzyScore } from "./fuzzy";
 import { bindingLabel, defaultKeys, isRecordKey, listStep, matchesBinding, parseKeyBindings, recordKeyLabel } from "./keybindings";
 import type { KeyBinding } from "./keybindings";
 import { clampDevtoolsFraction, computeLayout, dividerFraction, recordBarHeight } from "./layout";
 import type { DevtoolsPlacement } from "./layout";
 import { fetchSuggestions } from "./suggest";
 import { TabManager } from "./tabs";
+import type { TabApp } from "./tabs";
+import type { NewTabSuggestion } from "../ui/types";
 
 export interface SessionContext {
   tty?: string;
@@ -76,15 +86,14 @@ export function createSession(ctx: SessionContext): SessionHandle {
 
 const DEFAULT_URL = "https://github.com/zenbu-labs";
 
-const APP_MODE_FLAGS = [
-  "--no-toolbar",
-  "--no-shortcuts",
-  "--no-context-menu",
-  "--no-overlays",
-  "--no-frame",
-  "--allow-clipboard-read",
-  "--open-tabs-in-popup-stack",
-];
+const partitionPreloads = new Map<string, string | null>();
+function claimPartitionPreload(partition: string, preload: string | null) {
+  const existing = partitionPreloads.get(partition);
+  if (existing !== undefined && existing !== preload) {
+    throw new Error(`partition ${partition} already runs a different preload`);
+  }
+  partitionPreloads.set(partition, preload);
+}
 
 const FONT_FILE = path.join("assets", "fonts", "JetBrainsMono-Regular.ttf");
 
@@ -143,9 +152,29 @@ function bundledFontPath(): string {
 interface NewTabState {
   query: string;
   suggestions: string[];
+  apps: RegisteredApp[];
+  appMatches: RegisteredApp[];
   index: number;
   seq: number;
   timer: ReturnType<typeof setTimeout> | null;
+}
+
+function safeListApps(): RegisteredApp[] {
+  try {
+    return listApps();
+  } catch {
+    return [];
+  }
+}
+
+function matchApps(apps: RegisteredApp[], query: string): RegisteredApp[] {
+  if (!query.trim()) return [];
+  return apps
+    .map((app) => ({ app, score: Math.max(fuzzyScore(query, app.name), fuzzyScore(query, app.id)) }))
+    .filter((entry) => entry.score >= 2)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map((entry) => entry.app);
 }
 
 class Session {
@@ -156,12 +185,19 @@ class Session {
   private finding: Promise<Pane | null> | null = null;
   private readonly argv: string[];
   private readonly hideToolbar: boolean;
-  private readonly noShortcuts: boolean;
-  private readonly noContextMenu: boolean;
-  private readonly noOverlays: boolean;
   private readonly noFrame: boolean;
-  private readonly tabsAsPopups: boolean;
-  private readonly clipboardRead: boolean;
+  private readonly sessionFlags: {
+    noShortcuts: boolean;
+    noContextMenu: boolean;
+    noOverlays: boolean;
+    clipboardRead: boolean;
+    tabsAsPopups: boolean;
+  };
+  private readonly appIdentity: TabApp | null;
+  private readonly appPartitions: string[] = [];
+  private embedderIpc = false;
+  private wasBare = false;
+  private paletteApps: RegisteredApp[] = [];
   private readonly partition: string | null;
   private readonly socksPort: number | null;
   private readonly preload: string | null;
@@ -173,7 +209,9 @@ class Session {
   };
   private readonly onQuitRequest = (event: IpcMainEvent) => {
     if (!this.ownsSender(event)) return;
-    this.shutdown();
+    const tab = this.tabs.findByContents(event.sender.id);
+    if (tab?.app && this.tabs.count > 1) this.tabs.close(tab.id);
+    else this.shutdown();
   };
   private paletteBinding: KeyBinding[] = [];
   private findBinding: KeyBinding[] = [];
@@ -236,14 +274,21 @@ class Session {
     this.ctx = ctx;
     this.terminal = detect(ctx.env);
     this.marker = `terminal-browser:${ctx.key}`;
-    this.argv = ctx.argv.includes("--app-mode") ? [...ctx.argv, ...APP_MODE_FLAGS] : ctx.argv;
+    this.argv = ctx.argv;
     this.hideToolbar = this.argv.includes("--no-toolbar");
-    this.noShortcuts = this.argv.includes("--no-shortcuts");
-    this.noContextMenu = this.argv.includes("--no-context-menu");
-    this.noOverlays = this.argv.includes("--no-overlays");
     this.noFrame = this.argv.includes("--no-frame");
-    this.tabsAsPopups = this.argv.includes("--open-tabs-in-popup-stack");
-    this.clipboardRead = this.argv.includes("--allow-clipboard-read");
+    this.sessionFlags = {
+      noShortcuts: this.argv.includes("--no-shortcuts"),
+      noContextMenu: this.argv.includes("--no-context-menu"),
+      noOverlays: this.argv.includes("--no-overlays"),
+      clipboardRead: this.argv.includes("--allow-clipboard-read"),
+      tabsAsPopups: this.argv.includes("--open-tabs-in-popup-stack"),
+    };
+    const appName = flagValue(this.argv, "--app-name");
+    this.appIdentity = this.argv.includes("--app-mode")
+      ? { name: appName, id: appId(flagValue(this.argv, "--app-id") ?? appName ?? "app") }
+      : null;
+    this.wasBare = this.appIdentity != null;
     const sshTarget = flagValue(this.argv, "--ssh");
     const socksPort = Number(flagValue(this.argv, "--socks-port"));
     this.socksPort = Number.isInteger(socksPort) && socksPort > 0 ? socksPort : null;
@@ -256,20 +301,23 @@ class Session {
     configureBrowserSession(this.partition, (progress) => this.showDownload(progress));
     this.tabs = new TabManager(
       {
-        createController: (url, visible, onState) =>
+        createController: (url, visible, onState, options) =>
           new BrowserController(
             this.root!.createSurface(),
             this.popupSurface!,
             this.devtoolsSurface!,
             this.surfaceLayout!,
             url,
-            this.ctx.cwd,
-            this.windowBg,
-            visible,
-            this.partition,
-            this.tabsAsPopups,
-            this.clipboardRead,
-            this.ctx.key,
+            {
+              cwd: this.ctx.cwd,
+              background: this.windowBg,
+              visible,
+              partition: options.partition !== undefined ? options.partition : this.partition,
+              tabsAsPopups: this.sessionFlags.tabsAsPopups || options.app != null,
+              clipboardRead: this.sessionFlags.clipboardRead || options.app != null,
+              sessionKey: this.ctx.key,
+              appTabId: options.app ? options.tabId : null,
+            },
             onState,
           ),
         onActivated: () => {
@@ -290,6 +338,7 @@ class Session {
         onTabClosed: (id) => this.closeOrShutdown(id),
         tabSwitchAllowed: () => !this.activeRecord()?.reviewing,
         onTabsChanged: () => {
+          this.syncChromeComposition();
           this.registry?.update();
           for (const record of [...this.records.values()]) {
             if (record.active && this.tabs.stateFor(record.controller) == null) record.tabClosed();
@@ -361,7 +410,11 @@ class Session {
     this.root.setPointerShape("default");
     this.windowBg = this.themeBackground();
     this.installEmbedderApi();
-    this.tabs.create(this.fallbackState.url);
+    if (this.appIdentity) {
+      this.tabs.create(this.fallbackState.url, true, { app: this.appIdentity });
+    } else {
+      this.tabs.create(this.fallbackState.url);
+    }
     this.registry = new Registry({
       key: this.ctx.key,
       tty: this.ctx.tty ?? null,
@@ -376,6 +429,11 @@ class Session {
       splitDir: splitDirection(flagValue(this.argv, "--split-dir")),
       parentTty: flagValue(this.argv, "--parent-tty"),
       state: () => this.tabs.activeState ?? this.fallbackState,
+      interop: () => ({
+        mode: this.appIdentity ? ("app" as const) : ("browser" as const),
+      }),
+      openAppTab: (spec, app) => this.openAppTab(spec, app),
+      hasTab: (id) => this.tabs.has(id),
       openTab: (url, cwd) => this.tabs.create(url ? normalizeUrl(url, cwd) : DEFAULT_URL).id,
       activateTab: (id) => {
         if (!this.tabs.has(id) || this.activeRecord()?.reviewing) return false;
@@ -474,6 +532,24 @@ class Session {
     else this.tabs.close(id);
   }
 
+  private appTabActive(): boolean {
+    return this.tabs.active?.app != null;
+  }
+
+  private bareChrome(): boolean {
+    if (this.tabs.count === 0) return this.appIdentity != null;
+    return this.tabs.soleAppTab();
+  }
+
+  private syncChromeComposition() {
+    const bare = this.bareChrome();
+    if (bare === this.wasBare) return;
+    this.wasBare = bare;
+    this.recalculateLayout();
+    this.resizeSplitWindows();
+    this.render();
+  }
+
   shutdown(code = 0) {
     if (this.shuttingDown) return;
     this.shuttingDown = true;
@@ -488,6 +564,11 @@ class Session {
     try {
       browserSession(this.partition).flushStorageData();
     } catch { }
+    for (const partition of this.appPartitions) {
+      try {
+        browserSession(partition).flushStorageData();
+      } catch { }
+    }
     this.registry?.dispose();
     this.registry = null;
     this.tabs.stopAll();
@@ -530,7 +611,7 @@ class Session {
   }
 
   private broadcastTheme(): void {
-    if (!this.preload && !this.mainScript) return;
+    if (!this.embedderIpc) return;
     const payload = this.themePayload();
     if (!payload) return;
     this.tabs.eachController((controller) =>
@@ -538,10 +619,16 @@ class Session {
     );
   }
 
-  private installEmbedderApi(): void {
-    if (!this.preload && !this.mainScript) return;
+  private ensureEmbedderIpc(): void {
+    if (this.embedderIpc) return;
+    this.embedderIpc = true;
     ipcMain.on("terminal-browser:theme-request", this.onThemeRequest);
     ipcMain.on("terminal-browser:quit", this.onQuitRequest);
+  }
+
+  private installEmbedderApi(): void {
+    if (!this.preload && !this.mainScript) return;
+    this.ensureEmbedderIpc();
     if (this.preload) {
       const ses = browserSession(this.partition);
       registerPreloadOnce(ses, apiPreloadPath());
@@ -556,6 +643,50 @@ class Session {
           `main script failed: ${error instanceof Error ? error.message : String(error)}\n`,
         );
       }
+    }
+  }
+
+  private openAppTab(spec: OpenSpec, app: NonNullable<OpenSpec["app"]>): OpenResult {
+    const id = appId(app.id);
+    const partition = app.partition ?? `app-${id}`;
+    for (const file of [app.preload, app.mainScript]) {
+      if (file && !path.isAbsolute(file)) throw new Error(`${file} is not an absolute path`);
+    }
+    claimPartitionPreload(partition, app.preload ?? null);
+    const ses = configureBrowserSession(partition, (progress) => this.showDownload(progress));
+    if (app.preload) {
+      registerPreloadOnce(ses, apiPreloadPath());
+      registerPreloadOnce(ses, app.preload);
+    }
+    if (app.mainScript) createRequire(app.mainScript)(app.mainScript);
+    this.ensureEmbedderIpc();
+    if (!this.appPartitions.includes(partition)) this.appPartitions.push(partition);
+    const tab = this.tabs.create(spec.url ? normalizeUrl(spec.url) : DEFAULT_URL, true, {
+      app: { name: app.name ?? null, id },
+      partition,
+    });
+    return { tab: tab.id };
+  }
+
+  private launchApp(app: RegisteredApp) {
+    const existing = this.tabs.appTab(app.id);
+    if (existing) {
+      this.tabs.activate(existing.id);
+      return;
+    }
+    const env = { ...this.ctx.env };
+    if (this.registry) env.TERMINAL_BROWSER_INTEROP_TARGET = this.registry.socketPath;
+    try {
+      const child = spawn(app.bin, app.args, {
+        cwd: this.ctx.cwd,
+        detached: true,
+        stdio: "ignore",
+        env,
+      });
+      child.on("error", () => this.showToast(`could not launch ${app.name}`, "failed"));
+      child.unref();
+    } catch {
+      this.showToast(`could not launch ${app.name}`, "failed");
     }
   }
 
@@ -580,7 +711,7 @@ class Session {
         tabs={this.tabs.view()}
         newTab={
           this.newTab
-            ? { suggestions: this.newTab.suggestions, index: this.newTab.index }
+            ? { suggestions: this.newTabRows(), index: this.newTab.index }
             : null
         }
         urlEdit={this.urlEditOpen}
@@ -656,6 +787,7 @@ class Session {
       this.closeNewTabModal();
       if (text.trim()) this.tabs.create(searchOrUrl(text, this.ctx.cwd));
     },
+    newTabPick: (index) => this.pickNewTab(index),
     newTabCancel: () => this.closeNewTabModal(),
     popupPointer: (event) => this.tabs.activeController?.popup?.input.pointer(event),
     popupWheel: (event) => this.tabs.activeController?.popup?.input.wheel(event),
@@ -816,17 +948,18 @@ class Session {
   }
 
   private handleKey(event: EngineKeyEvent) {
+    const noShortcuts = this.sessionFlags.noShortcuts || this.appTabActive();
     const browser = this.tabs.activeController;
     if (browser?.popup) {
       if (event.kind !== "release" && event.key === "escape") {
         browser.popup.close();
         return;
       }
-      if (!this.noShortcuts && event.kind !== "release" && event.mods.ctrl && event.key === "q") {
+      if (!noShortcuts && event.kind !== "release" && event.mods.ctrl && event.key === "q") {
         this.shutdown();
         return;
       }
-      if (!this.noShortcuts && event.kind !== "release" && this.cmdHeld(event)) {
+      if (!noShortcuts && event.kind !== "release" && this.cmdHeld(event)) {
         const direction = zoomDirection(event.key);
         if (direction !== null) {
           this.applyZoom(direction);
@@ -842,7 +975,7 @@ class Session {
     if (event.kind !== "release") {
       const quitKey =
         event.key === "q" || (process.platform === "darwin" && event.key === "c");
-      if (!this.noShortcuts && event.mods.ctrl && quitKey) {
+      if (!noShortcuts && event.mods.ctrl && quitKey) {
         this.shutdown();
         return;
       }
@@ -869,7 +1002,7 @@ class Session {
         const step = listStep(event);
         if (event.key === "escape") this.closeNewTabModal();
         else if (step) {
-          const count = session.suggestions.length;
+          const count = this.newTabRows().length;
           if (count > 0) {
             session.index =
               step > 0
@@ -882,8 +1015,8 @@ class Session {
             this.render();
           }
         } else if (event.key === "enter") {
-          const text = session.index >= 0 ? session.suggestions[session.index] : session.query;
-          this.actions.newTabSubmit(text);
+          if (session.index >= 0) this.pickNewTab(session.index);
+          else this.actions.newTabSubmit(session.query);
         }
         return;
       }
@@ -892,7 +1025,7 @@ class Session {
         return;
       }
       if (!this.findOpen && this.activeRecord()?.handleKey(event)) return;
-      if (!this.noShortcuts) {
+      if (!noShortcuts) {
         if (isRecordKey(event)) {
           if (!this.activeRecord()) void this.startRecording();
           return;
@@ -930,7 +1063,7 @@ class Session {
         browser?.findNext(!event.mods.shift);
         return;
       }
-      if (!this.noShortcuts) {
+      if (!noShortcuts) {
         if (this.accelHeld(event) && event.key === "r") {
           this.activeRecord()?.reloaded();
           browser?.reload();
@@ -999,7 +1132,7 @@ class Session {
   }
 
   private showZoomHud(factor: number) {
-    if (this.noOverlays) return;
+    if (this.sessionFlags.noOverlays || this.appTabActive()) return;
     this.zoomHud = factor;
     if (this.zoomHudTimer) clearTimeout(this.zoomHudTimer);
     this.zoomHudTimer = setTimeout(() => {
@@ -1011,7 +1144,7 @@ class Session {
   }
 
   private showDownload(progress: DownloadProgress) {
-    if (this.noOverlays) return;
+    if (this.sessionFlags.noOverlays || this.appTabActive()) return;
     const percent =
       progress.total > 0 ? Math.round((progress.received / progress.total) * 100) : null;
     if (
@@ -1035,7 +1168,7 @@ class Session {
   }
 
   private showToast(text: string, state: "done" | "failed" | "alert", detail?: string) {
-    if (this.noOverlays) return;
+    if (this.sessionFlags.noOverlays || this.appTabActive()) return;
     this.toast = { text, detail, failed: state === "failed", alert: state === "alert" };
     if (this.toastTimer) clearTimeout(this.toastTimer);
     this.toastTimer = setTimeout(() => {
@@ -1165,7 +1298,7 @@ class Session {
   }
 
   private openPageMenu(params: Electron.ContextMenuParams) {
-    if (this.noContextMenu || !this.surfaceLayout) return;
+    if (this.sessionFlags.noContextMenu || this.appTabActive() || !this.surfaceLayout) return;
     if (this.palette || this.newTab || this.urlEditOpen) return;
     if (this.tabs.activeController?.popup) return;
     const scale = this.surfaceLayout.scale;
@@ -1261,10 +1394,43 @@ class Session {
 
   private openNewTabModal() {
     if (this.newTab) return;
-    this.newTab = { query: "", suggestions: [], index: -1, seq: 0, timer: null };
+    this.newTab = {
+      query: "",
+      suggestions: [],
+      apps: safeListApps(),
+      appMatches: [],
+      index: -1,
+      seq: 0,
+      timer: null,
+    };
     this.blurToOverlay();
     this.root?.setKeyCapture(["enter", "up", "down"]);
     this.render();
+  }
+
+  private newTabRows(): NewTabSuggestion[] {
+    const session = this.newTab;
+    if (!session) return [];
+    return [
+      ...session.appMatches.map((app) => ({
+        kind: "app" as const,
+        id: app.id,
+        name: app.name,
+      })),
+      ...session.suggestions.map((text) => ({ kind: "search" as const, text })),
+    ];
+  }
+
+  private pickNewTab(index: number) {
+    const row = this.newTabRows()[index];
+    if (!row) return;
+    if (row.kind === "app") {
+      const app = this.newTab?.apps.find((entry) => entry.id === row.id);
+      this.closeNewTabModal();
+      if (app) this.launchApp(app);
+      return;
+    }
+    this.actions.newTabSubmit(row.text);
   }
 
   private closeNewTabModal() {
@@ -1281,6 +1447,7 @@ class Session {
     if (!session) return;
     session.query = text;
     session.index = -1;
+    session.appMatches = matchApps(session.apps, text);
     if (session.timer) clearTimeout(session.timer);
     session.timer = null;
     if (!text.trim()) {
@@ -1301,7 +1468,7 @@ class Session {
       .then((suggestions) => {
         if (this.newTab !== session || session.seq !== seq) return;
         session.suggestions = suggestions;
-        if (session.index >= session.suggestions.length) session.index = -1;
+        if (session.index >= this.newTabRows().length) session.index = -1;
         this.render();
       })
       .catch(() => { });
@@ -1326,6 +1493,7 @@ class Session {
 
   private openPalette() {
     if (this.palette) return;
+    this.paletteApps = safeListApps();
     this.palette = { query: "", index: 0 };
     this.blurToOverlay();
     this.root?.setKeyCapture(["enter", "up", "down"]);
@@ -1390,6 +1558,12 @@ class Session {
           },
         ]
         : []),
+      ...this.paletteApps.map((app) => ({
+        id: `app:${app.id}`,
+        label: `open ${app.name}`,
+        shortcut: "",
+        run: () => this.launchApp(app),
+      })),
     ];
   }
 
@@ -1405,8 +1579,8 @@ class Session {
     const result = computeLayout(
       this.root.info,
       this.displayScale,
-      this.hideToolbar,
-      this.noFrame,
+      this.hideToolbar || this.bareChrome(),
+      this.noFrame || this.bareChrome(),
       reviewing ? null : placement,
       reviewing ? recordBarHeight(this.root.info) : 0,
     );

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -669,11 +669,6 @@ class Session {
   }
 
   private launchApp(app: RegisteredApp) {
-    const existing = this.tabs.appTab(app.id);
-    if (existing) {
-      this.tabs.activate(existing.id);
-      return;
-    }
     const env = { ...this.ctx.env };
     if (this.registry) env.TERMINAL_BROWSER_INTEROP_TARGET = this.registry.socketPath;
     try {

--- a/browser/src/session/tabs.ts
+++ b/browser/src/session/tabs.ts
@@ -166,10 +166,6 @@ export class TabManager {
     return this.tabs.length === 1 && this.tabs[0].app != null;
   }
 
-  appTab(id: string): Tab | null {
-    return this.tabs.find((tab) => tab.app?.id === id) ?? null;
-  }
-
   findByContents(contentsId: number): Tab | null {
     return this.tabs.find((tab) => tab.controller.hasContents(contentsId)) ?? null;
   }

--- a/browser/src/session/tabs.ts
+++ b/browser/src/session/tabs.ts
@@ -5,11 +5,22 @@ import type { BrowserState } from "../page/types";
 import type { TabRow } from "../ui/types";
 import { displayUrl } from "../url";
 
+export interface TabApp {
+  name: string | null;
+  id: string;
+}
+
+export interface TabOptions {
+  app?: TabApp;
+  partition?: string | null;
+}
+
 export interface Tab {
   readonly id: number;
   state: BrowserState;
   controller: BrowserController;
   targetId: string | null;
+  app: TabApp | null;
 }
 
 export interface TabTarget {
@@ -18,6 +29,7 @@ export interface TabTarget {
   title: string;
   active: boolean;
   targetId: string | null;
+  app?: TabApp | null;
   timeOrigin?: number | null;
 }
 
@@ -27,6 +39,7 @@ export interface TabHost {
     url: string,
     visible: boolean,
     onState: (state: BrowserState) => void,
+    options: TabOptions & { tabId: number },
   ): BrowserController;
   onActivated(): void;
   onActiveState(state: BrowserState, urlChanged: boolean): void;
@@ -70,22 +83,27 @@ export class TabManager {
   }
 
   
-  create(url: string, activate = true): Tab {
-    const tab = { id: this.seq++, state: initialBrowserState(url), targetId: null } as Tab;
-    this.attachController(tab, url, activate);
+  create(url: string, activate = true, options: TabOptions = {}): Tab {
+    const tab = {
+      id: this.seq++,
+      state: initialBrowserState(url),
+      targetId: null,
+      app: options.app ?? null,
+    } as Tab;
+    this.attachController(tab, url, activate, options);
     this.tabs.push(tab);
     if (activate) this.activate(tab.id);
     this.host.onTabsChanged();
     return tab;
   }
 
-  private attachController(tab: Tab, url: string, visible: boolean) {
+  private attachController(tab: Tab, url: string, visible: boolean, options: TabOptions) {
     tab.controller = this.host.createController(url, visible, (state) => {
       const urlChanged = state.url !== tab.state.url;
       tab.state = state;
       if (tab.id === this.activeId) this.host.onActiveState(state, urlChanged);
       this.host.requestRender();
-    });
+    }, { ...options, tabId: tab.id });
     tab.controller.onCursorChange = () => {
       if (tab.id === this.activeId) this.host.onCursorChanged();
     };
@@ -144,16 +162,34 @@ export class TabManager {
     return this.tabs.some((tab) => tab.id === id);
   }
 
+  soleAppTab(): boolean {
+    return this.tabs.length === 1 && this.tabs[0].app != null;
+  }
+
+  appTab(id: string): Tab | null {
+    return this.tabs.find((tab) => tab.app?.id === id) ?? null;
+  }
+
+  findByContents(contentsId: number): Tab | null {
+    return this.tabs.find((tab) => tab.controller.hasContents(contentsId)) ?? null;
+  }
+
   stateFor(controller: BrowserController): BrowserState | null {
     return this.tabs.find((tab) => tab.controller === controller)?.state ?? null;
+  }
+
+  private label(tab: Tab): string {
+    if (tab.app?.name) return tab.app.name;
+    return tab.state.title || displayUrl(tab.state.url);
   }
 
   view(): TabRow[] {
     return this.tabs.map((tab) => ({
       id: tab.id,
-      title: tab.state.title || displayUrl(tab.state.url),
-      favicon: tab.state.favicon,
+      title: this.label(tab),
+      favicon: tab.app ? null : tab.state.favicon,
       active: tab.id === this.activeId,
+      app: tab.app != null,
     }));
   }
 
@@ -164,6 +200,7 @@ export class TabManager {
       title: tab.state.title,
       active: tab.id === this.activeId,
       targetId: tab.targetId,
+      app: tab.app,
     }));
   }
 
@@ -177,6 +214,7 @@ export class TabManager {
           title: tab.state.title,
           active: tab.id === this.activeId,
           targetId: tab.targetId,
+          app: tab.app,
           timeOrigin: await tab.controller.fingerprint(),
         };
       }),

--- a/browser/src/ui/icons.tsx
+++ b/browser/src/ui/icons.tsx
@@ -43,6 +43,10 @@ export const ICONS = {
     "M 4 8.2 L 8.3 8.2 L 9.8 6 L 14.2 6 L 15.7 8.2 L 20 8.2 L 20 18 L 4 18 Z " +
     arcPath(12, 12.9, 3.1, 0, 360),
   pause: "M 9.2 6.8 L 9.2 17.2 M 14.8 6.8 L 14.8 17.2",
+  terminal:
+    "M 5 3 L 19 3 C 20.104 3 21 3.896 21 5 L 21 19 C 21 20.104 20.104 21 19 21 " +
+    "L 5 21 C 3.896 21 3 20.104 3 19 L 3 5 C 3 3.896 3.896 3 5 3 Z " +
+    "M 7 11 L 9 9 L 7 7 M 11 13 L 15 13",
 };
 
 export type IconName = keyof typeof ICONS;

--- a/browser/src/ui/modals.tsx
+++ b/browser/src/ui/modals.tsx
@@ -235,14 +235,15 @@ export function NewTabCard({
       {view.suggestions.length > 0 && (
         <Box style={{ flexDirection: "column" }}>
           {view.suggestions.map((suggestion, i) => {
+            const text = suggestion.kind === "app" ? suggestion.name : suggestion.text;
             const maxChars = Math.floor((cardW - rem * 3.15) / (rem * 0.95 * 0.6));
             const shown =
-              suggestion.length > maxChars
-                ? `${suggestion.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`
-                : suggestion;
+              text.length > maxChars
+                ? `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`
+                : text;
             return (
               <Box
-                key={`${i}:${suggestion}`}
+                key={suggestion.kind === "app" ? `app:${suggestion.id}` : `${i}:${text}`}
                 style={{
                   height: rowH,
                   alignItems: "center",
@@ -252,9 +253,13 @@ export function NewTabCard({
                   hoverBackground: theme.hover,
                   cornerRadius: lastRowRadius(i === view.suggestions.length - 1, rem),
                 }}
-                onClick={() => actions.newTabSubmit(suggestion)}
+                onClick={() => actions.newTabPick(i)}
               >
-                <Icon icon="search" size={rem * 0.8} color={theme.disabled} />
+                <Icon
+                  icon={suggestion.kind === "app" ? "terminal" : "search"}
+                  size={rem * 0.8}
+                  color={theme.disabled}
+                />
                 <Text
                   style={{
                     flexGrow: 1,

--- a/browser/src/ui/tab-strip.tsx
+++ b/browser/src/ui/tab-strip.tsx
@@ -92,7 +92,8 @@ export function TabStrip({
   const single = tabs.length <= 1;
   const [hovered, setHovered] = useState<number | null>(null);
   const activeLabel = displayUrl(state.url);
-  const label = (tab: TabRow) => (tab.active ? activeLabel : tab.title || "new tab");
+  const label = (tab: TabRow) =>
+    tab.app ? tab.title || "app" : tab.active ? activeLabel : tab.title || "new tab";
   const charW = rem * 0.82 * 0.6;
   const closeW = rem * 1.25;
   const closeGap = rem * 0.25;
@@ -132,7 +133,9 @@ export function TabStrip({
             flexShrink: 1,
             overflow: "hidden",
           }}
-          onClick={() => (tab.active ? actions.urlEdit() : actions.tabSwitch(tab.id))}
+          onClick={() =>
+            tab.active && !tab.app ? actions.urlEdit() : actions.tabSwitch(tab.id)
+          }
           onMouseEnter={() => setHovered(tab.id)}
           onMouseLeave={() => setHovered((id) => (id === tab.id ? null : id))}
         >

--- a/browser/src/ui/types.ts
+++ b/browser/src/ui/types.ts
@@ -6,8 +6,12 @@ export interface PaletteView {
   items: { id: string; label: string; shortcut: string }[];
 }
 
+export type NewTabSuggestion =
+  | { kind: "search"; text: string }
+  | { kind: "app"; id: string; name: string };
+
 export interface NewTabView {
-  suggestions: string[];
+  suggestions: NewTabSuggestion[];
   index: number;
 }
 
@@ -16,6 +20,7 @@ export interface TabRow {
   title: string;
   favicon: string | null;
   active: boolean;
+  app: boolean;
 }
 
 export interface PopupView {
@@ -69,6 +74,7 @@ export interface ChromeActions {
   tabNew(): void;
   newTabQuery(text: string): void;
   newTabSubmit(text: string): void;
+  newTabPick(index: number): void;
   newTabCancel(): void;
   popupPointer(event: PointerEvent): void;
   popupWheel(event: WheelEvent): void;

--- a/cli/src/control.ts
+++ b/cli/src/control.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import net from "node:net";
 
 export function control(
@@ -6,6 +7,7 @@ export function control(
   timeoutMs = 10_000,
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
+    const id = randomUUID();
     const connection = net.connect(socketPath);
     const timer = setTimeout(() => {
       connection.destroy();
@@ -25,16 +27,18 @@ export function control(
       connection.destroy();
       try {
         const response = JSON.parse(buffer.slice(0, newline)) as {
+          id?: string | null;
           ok: boolean;
           data?: unknown;
           error?: string;
         };
-        if (response.ok) resolve(response.data);
-        else reject(new Error(response.error ?? "control request failed"));
+        if (!response.ok) reject(new Error(response.error ?? "control request failed"));
+        else if (response.id !== id) reject(new Error("response id mismatch"));
+        else resolve(response.data);
       } catch (error) {
         reject(error);
       }
     });
-    connection.write(`${JSON.stringify(request)}\n`);
+    connection.write(`${JSON.stringify({ id, ...request })}\n`);
   });
 }

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -40,13 +40,15 @@ Options:
   --allow-clipboard-read
                         Lets websites read from clipboard.
   --no-toolbar          No toolbar or tab strip
-  --no-shortcuts        No browser shortcuts, keys go to the page
+  --no-shortcuts        No browser shortcuts
   --no-context-menu     No right-click menu
   --no-overlays         No toasts or HUDs drawn over the page
-  --no-frame            No border or padding, the page fills the pane
-  --app-mode            Shorthand for --no-toolbar --no-shortcuts
-                        --no-context-menu --no-overlays --no-frame
-                        --allow-clipboard-read --open-tabs-in-popup-stack
+  --no-frame            No border or padding around the web page
+  --app-mode            Enables configuration to disable terminal-browser features to make optimal for application embedding
+  --app-name=<name>     The name of the application
+  --app-id=<id>         The identifier of the application
+  --no-merge            Do not open the terminal-browser instance as a tab in a neighbor terminal-browser
+
 
 Examples:
   terminal-browser open localhost:3000
@@ -68,12 +70,12 @@ Options:
 `,
   },
   setup: {
-    summary: "Configure installed terminals so terminal-browser works best",
+    summary: "Configure terminals and agents so terminal-browser works best",
     usage: "terminal-browser setup",
     body: `
-Finds the terminals on this machine and fixes any settings that would keep the
-browser from drawing in them. Editors built on vscode ship with terminal images
-switched off, so this turns "terminal.integrated.enableImages" on in each one.
+Sets up configuration to make terminal-browser work best, this includes:
+- installing agent skills
+- enabling configuration settings in terminals that is required for terminal-browser to work
 
 `,
   },
@@ -103,6 +105,30 @@ Options:
 Examples:
   terminal-browser new-tab github.com
   terminal-browser new-tab --browser 90107-1 localhost:3000
+`,
+  },
+  apps: {
+    summary: "Lists registered terminal-browser apps",
+    usage: "terminal-browser apps [--json]",
+    body: `
+Lists the id, name, and binary path of registered terminal-browser apps. Apps can be registered
+using terminal-browser register-app. If an app is registered it can be opened through the terminal-browser
+new tab command palette after searching for its name.
+`,
+  },
+  "register-app": {
+    summary: "Register a terminal-browser application",
+    usage: "terminal-browser register-app --name <name> --bin <path> [--id <id>] [--args \"…\"]",
+    body: `
+Registers metadata for a terminal-browser application to ~/.local/share/terminal-browser-interop/apps/<id>.json. This enables functionality
+when a user is using terminal-browser, and lets other applications discover terminal-browser apps.
+`,
+  },
+  "unregister-app": {
+    summary: "Unregister a terminal-browser application",
+    usage: "terminal-browser unregister-app <id>",
+    body: `
+Remove application metadata from ~/.local/share/terminal-browser-interop/apps/<id>.json.
 `,
   },
   shutdown: {

--- a/cli/src/instances.ts
+++ b/cli/src/instances.ts
@@ -11,6 +11,7 @@ export interface TabTarget {
   title: string;
   active: boolean;
   targetId: string | null;
+  app?: { name: string | null; id: string } | null;
   timeOrigin?: number | null;
 }
 

--- a/cli/src/interop.ts
+++ b/cli/src/interop.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from "node:crypto";
+import net from "node:net";
+
+import { callerTty } from "pixel-terminals";
+import type { Terminal } from "pixel-terminals";
+import { INTEROP_PROTOCOL_VERSIONS, listInteropInstances } from "pixel-store";
+import type { InteropInstance, OpenResult, OpenSpec } from "pixel-store";
+
+import { control } from "./control";
+
+export async function findHosts(terminal: Terminal | null): Promise<InteropInstance[]> {
+  const records = listInteropInstances().filter((record) =>
+    record.protocolVersions.some((version) => INTEROP_PROTOCOL_VERSIONS.includes(version)),
+  );
+  const target = process.env.TERMINAL_BROWSER_INTEROP_TARGET;
+  if (target) return records.filter((record) => record.socket === target);
+  if (records.length === 0 || !terminal) return [];
+  const current = await terminal
+    .getCurrentPane?.({ tty: callerTty().path, cwd: process.cwd() })
+    .catch(() => null);
+  if (!current) return [];
+  const answers = await Promise.all(
+    records.map(async (record) => {
+      const where = (await control(record.socket, { cmd: "where" }, 2000).catch(() => null)) as {
+        terminal: string | null;
+        tab: string | null;
+      } | null;
+      if (!where || where.terminal !== terminal.name) return null;
+      if (!where.tab || where.tab !== current.tab) return null;
+      return record;
+    }),
+  );
+  return answers
+    .filter((record): record is InteropInstance => record !== null)
+    .sort((a, b) =>
+      a.mode === b.mode ? b.startedAt - a.startedAt : a.mode === "browser" ? -1 : 1,
+    );
+}
+
+export function openUrlInHost(socket: string, url: string | undefined): Promise<{ tab: number }> {
+  return control(socket, { cmd: "interop/1/open", url }) as Promise<{ tab: number }>;
+}
+
+export interface AppAttachment {
+  result: OpenResult;
+  closed: Promise<{ reason: string }>;
+  close(): void;
+}
+
+export function openAppInHost(
+  socket: string,
+  spec: OpenSpec,
+  timeoutMs = 15_000,
+): Promise<AppAttachment> {
+  return new Promise((resolve, reject) => {
+    const connection = net.connect(socket);
+    let buffer = "";
+    let settled = false;
+    let closedResolve!: (value: { reason: string }) => void;
+    const closed = new Promise<{ reason: string }>((res) => (closedResolve = res));
+    const timer = setTimeout(() => {
+      if (settled) return;
+      connection.destroy();
+      reject(new Error("open timed out"));
+    }, timeoutMs);
+    connection.setEncoding("utf8");
+    connection.on("error", (error) => {
+      if (!settled) {
+        clearTimeout(timer);
+        reject(error);
+      } else closedResolve({ reason: "connection lost" });
+    });
+    connection.on("close", () => {
+      if (settled) closedResolve({ reason: "closed" });
+    });
+    const id = randomUUID();
+    connection.on("data", (chunk: string) => {
+      buffer += chunk;
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        newline = buffer.indexOf("\n");
+        let message: {
+          id?: string | null;
+          ok?: boolean;
+          data?: OpenResult;
+          error?: string;
+          event?: string;
+          reason?: string;
+        };
+        try {
+          message = JSON.parse(line) as typeof message;
+        } catch {
+          continue;
+        }
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          if (message.ok && message.data && message.id === id) {
+            resolve({ result: message.data, closed, close: () => connection.destroy() });
+          } else {
+            connection.destroy();
+            reject(new Error(message.error ?? "open failed"));
+          }
+        } else if (message.event === "app-closed" && message.id === id) {
+          closedResolve({ reason: message.reason ?? "closed" });
+          connection.destroy();
+        }
+      }
+    });
+    connection.write(`${JSON.stringify({ id, cmd: "interop/1/open", ...spec })}\n`);
+  });
+}

--- a/cli/src/ls.ts
+++ b/cli/src/ls.ts
@@ -44,7 +44,9 @@ function render(list: Listed[]): string {
     lines.push(`${browser.key}  ${where}${browser.inCurrentTab ? "  (this tab)" : ""}`);
     for (const tab of browser.tabs) {
       const mark = tab.active ? "*" : " ";
-      lines.push(`  ${mark} ${tab.id}  ${tab.title || tab.url}`);
+      const page = tab.title || tab.url;
+      const label = tab.app ? `${tab.app.name ?? page} (app)` : page;
+      lines.push(`  ${mark} ${tab.id}  ${label}`);
       lines.push(`      ${tab.url}`);
       lines.push(`      target ${tab.targetId ?? "pending"}`);
     }

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -4,7 +4,17 @@ import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 
-import { DAEMON_SOCKET, LOGS_DIR, ensureDataDir } from "pixel-store";
+import {
+  DAEMON_SOCKET,
+  LOGS_DIR,
+  appId,
+  ensureDataDir,
+  instanceKey,
+  listApps,
+  registerApp,
+  unregisterApp,
+} from "pixel-store";
+import type { OpenSpec } from "pixel-store";
 import {
   callerTty,
   canSplit,
@@ -20,6 +30,7 @@ import { setupCommand } from "./editors";
 import { commandHelp, helpTopics, rootHelp } from "./help";
 import { browsers, describe, recordKey } from "./instances";
 import type { Browser } from "./instances";
+import { findHosts, openAppInHost, openUrlInHost } from "./interop";
 import { lsCommand } from "./ls";
 import { instances } from "./registry";
 import { apparmorSetup, deniedRefusal, linuxSandboxError, sandboxRefusal } from "./sandbox";
@@ -445,6 +456,7 @@ async function newTabCommand(url: string | undefined, key: string | undefined): 
     print(await control(target.socket, where));
     return 0;
   }
+  if (!key && !mergeDisabled() && (await tryAdopt(url ? [url] : []))) return 0;
   await requireGraphics(check);
   const argv = url ? [url] : [];
   if (interactiveTty()) return openHere(argv);
@@ -478,6 +490,8 @@ const BROWSER_FLAGS = [
   "--ssh-bundle-dir=",
   "--preload=",
   "--main-script=",
+  "--app-name=",
+  "--app-id=",
   "--palette-key=",
   "--find-key=",
   "--devtools-key=",
@@ -525,16 +539,77 @@ function requirePaneAccess(): void {
   if (refusal) fail(refusal);
 }
 
+function mergeDisabled(): boolean {
+  return process.env.TERMINAL_BROWSER_NO_MERGE === "1";
+}
+
+async function tryAdopt(args: string[]): Promise<boolean> {
+  const terminal = (await currentTerminal()).terminal;
+  const hosts = await findHosts(terminal).catch(() => []);
+  if (hosts.length === 0) return false;
+  const url = args.find((arg) => !arg.startsWith("-"));
+  const resolved = url && fs.existsSync(url) ? path.resolve(url) : url;
+  if (!args.includes("--app-mode")) {
+    for (const host of hosts) {
+      try {
+        const opened = await openUrlInHost(host.socket, resolved);
+        print({ adopted: instanceKey(host), socket: host.socket, tab: opened.tab });
+        return true;
+      } catch {}
+    }
+    return false;
+  }
+  if (!resolved) return false;
+  const name = flagEq(args, "--app-name");
+  const idFlag = flagEq(args, "--app-id");
+  const app: NonNullable<OpenSpec["app"]> = { id: appId(idFlag ?? name ?? "app") };
+  if (name !== undefined) app.name = name;
+  const partition = flagEq(args, "--partition");
+  if (partition) app.partition = partition;
+  const preload = flagEq(args, "--preload");
+  if (preload) app.preload = path.resolve(preload);
+  const mainScript = flagEq(args, "--main-script");
+  if (mainScript) app.mainScript = path.resolve(mainScript);
+  const spec: OpenSpec = { url: resolved, app };
+  for (const host of hosts) {
+    let attachment;
+    try {
+      attachment = await openAppInHost(host.socket, spec);
+    } catch {
+      continue;
+    }
+    print({
+      adopted: instanceKey(host),
+      socket: host.socket,
+      tab: attachment.result.tab,
+    });
+    const finish = () => {
+      attachment.close();
+      process.exit(0);
+    };
+    process.on("SIGINT", finish);
+    process.on("SIGTERM", finish);
+    process.on("SIGHUP", finish);
+    await attachment.closed;
+    process.exit(0);
+  }
+  return false;
+}
+
 async function openCommand(args: string[]) {
   requirePaneAccess();
   const split = takeSplitFlag(args);
   const size = takeSizeFlag(args);
+  const noMerge = takeBoolFlag(args, "--no-merge") || mergeDisabled();
   if (size !== null && !split) fail("--size only applies to a split (--split <direction>)");
   takeSshFlags(args);
   rejectUnknownFlags(args);
   const positionals = args.filter((arg) => !arg.startsWith("-"));
   if (positionals.length > 1) {
     fail(`unexpected ${positionals[1]} (one url; --split <direction> opens a new pane)`);
+  }
+  if (!noMerge && !args.some((arg) => arg.startsWith("--ssh="))) {
+    if (await tryAdopt(args)) return;
   }
   await requireGraphics(await currentTerminal());
   if (!split && interactiveTty()) {
@@ -575,6 +650,57 @@ function asksForHelp(args: string[]): boolean {
   const end = args.indexOf("--");
   const own = end < 0 ? args : args.slice(0, end);
   return own.includes("--help") || own.includes("-h");
+}
+
+function registerAppCommand(args: string[]): number {
+  const idFlag = takeFlag(args, "--id");
+  const name = takeFlag(args, "--name");
+  const bin = takeFlag(args, "--bin");
+  const argsFlag = takeFlag(args, "--args");
+  if (!name) fail("register-app needs --name");
+  if (!bin) fail("register-app needs --bin");
+  const binPath = path.resolve(bin);
+  if (!fs.existsSync(binPath)) fail(`no such file ${binPath}`);
+  const id = appId(idFlag ?? name);
+  registerApp({
+    id,
+    name,
+    bin: binPath,
+    args: argsFlag ? argsFlag.split(/\s+/).filter(Boolean) : [],
+  });
+  process.stdout.write(`registered ${name} (${id})\n`);
+  return 0;
+}
+
+function unregisterAppCommand(args: string[]): number {
+  const id = args.find((arg) => !arg.startsWith("-"));
+  if (!id) fail("unregister-app needs an app id (terminal-browser apps)");
+  if (!unregisterApp(appId(id))) fail(`no registered app ${id}`);
+  process.stdout.write(`unregistered ${id}\n`);
+  return 0;
+}
+
+function appsCommand(args: string[]): number {
+  const json = takeBoolFlag(args, "--json");
+  const apps = listApps();
+  if (json) {
+    print(apps);
+    return 0;
+  }
+  if (apps.length === 0) {
+    process.stdout.write("no apps registered\n");
+    return 0;
+  }
+  const rows = apps.map((app) => [app.id, app.name, app.bin]);
+  const header = ["id", "name", "bin"];
+  const widths = header.map((label, col) =>
+    Math.max(label.length, ...rows.map((row) => row[col].length)),
+  );
+  for (const row of [header, ...rows]) {
+    const line = row.map((cell, col) => cell.padEnd(widths[col])).join("  ");
+    process.stdout.write(`${line.trimEnd()}\n`);
+  }
+  return 0;
 }
 
 function helpCommand(topic: string | undefined): number {
@@ -621,6 +747,9 @@ async function main(): Promise<number> {
   }
   if (command === "upgrade") return upgradeCommand();
   if (command === "shutdown") return shutdownDaemon();
+  if (command === "register-app") return registerAppCommand(args);
+  if (command === "unregister-app") return unregisterAppCommand(args);
+  if (command === "apps") return appsCommand(args);
   if (command === "new-tab") {
     requirePaneAccess();
     const key = takeFlag(args, "--browser");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       drizzle-orm:
         specifier: ^0.44.5
         version: 0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.0.0

--- a/store/package.json
+++ b/store/package.json
@@ -10,7 +10,8 @@
     "db:generate": "drizzle-kit generate && tsx scripts/embed-migrations.ts"
   },
   "dependencies": {
-    "drizzle-orm": "^0.44.5"
+    "drizzle-orm": "^0.44.5",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/store/src/index.ts
+++ b/store/src/index.ts
@@ -15,3 +15,20 @@ export { appState, instances, settings } from "./schema";
 export type { DevtoolsDock, InstanceRow, NewInstanceRow, SettingsRow } from "./schema";
 export { listInstances, removeInstance, upsertInstance } from "./instances";
 export { lastUrl, setLastUrl } from "./app-state";
+export {
+  INTEROP_APPS_DIR,
+  INTEROP_INSTANCES_DIR,
+  INTEROP_PROTOCOL_VERSIONS,
+  advertiseInstance,
+  appId,
+  instanceKey,
+  interopInstanceSchema,
+  listApps,
+  listInteropInstances,
+  openSpecSchema,
+  registerApp,
+  registeredAppSchema,
+  unregisterApp,
+  withdrawInstance,
+} from "./interop";
+export type { InteropInstance, OpenResult, OpenSpec, RegisteredApp } from "./interop";

--- a/store/src/interop.ts
+++ b/store/src/interop.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { z } from "zod";
+
+const HOME = os.homedir();
+
+function interopRoot(kind: "state" | "share"): string {
+  const override = process.env.TERMINAL_BROWSER_INTEROP_DIR;
+  if (override && path.isAbsolute(override)) return override;
+  return path.join(HOME, ".local", kind, "terminal-browser-interop");
+}
+
+export const INTEROP_INSTANCES_DIR = path.join(interopRoot("state"), "instances");
+export const INTEROP_APPS_DIR = path.join(interopRoot("share"), "apps");
+
+export const INTEROP_PROTOCOL_VERSIONS = [1];
+
+export const openSpecSchema = z
+  .object({
+    url: z.string().optional(),
+    app: z
+      .object({
+        id: z.string().min(1),
+        name: z.string().optional(),
+        partition: z.string().optional(),
+        preload: z.string().optional(),
+        mainScript: z.string().optional(),
+      })
+      .optional(),
+  })
+  .refine((spec) => !spec.app || spec.url !== undefined);
+export type OpenSpec = z.infer<typeof openSpecSchema>;
+
+export interface OpenResult {
+  tab: number;
+}
+
+export const interopInstanceSchema = z.object({
+  protocolVersions: z.array(z.number()),
+  mode: z.enum(["browser", "app"]).catch("browser"),
+  pid: z.number(),
+  socket: z.string(),
+  startedAt: z.number().catch(0),
+});
+export type InteropInstance = z.infer<typeof interopInstanceSchema>;
+
+export function instanceKey(record: InteropInstance): string {
+  return path.basename(record.socket, ".sock");
+}
+
+function instanceFile(key: string): string {
+  return path.join(INTEROP_INSTANCES_DIR, `${key.replace(/[^\w-]/g, "_")}.json`);
+}
+
+export function advertiseInstance(key: string, record: InteropInstance): void {
+  try {
+    fs.mkdirSync(INTEROP_INSTANCES_DIR, { recursive: true });
+    fs.writeFileSync(instanceFile(key), `${JSON.stringify(record)}\n`);
+  } catch {}
+}
+
+export function withdrawInstance(key: string): void {
+  try {
+    fs.rmSync(instanceFile(key), { force: true });
+  } catch {}
+}
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readJson(file: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function listInteropInstances(): InteropInstance[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(INTEROP_INSTANCES_DIR);
+  } catch {
+    return [];
+  }
+  const records: InteropInstance[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const file = path.join(INTEROP_INSTANCES_DIR, name);
+    const parsed = interopInstanceSchema.safeParse(readJson(file));
+    if (!parsed.success) continue;
+    if (!alive(parsed.data.pid) || !fs.existsSync(parsed.data.socket)) {
+      fs.rmSync(file, { force: true });
+      continue;
+    }
+    records.push(parsed.data);
+  }
+  return records.sort((a, b) => b.startedAt - a.startedAt);
+}
+
+const APP_MANIFEST_VERSION = 1;
+
+export const registeredAppSchema = z.object({
+  version: z.number(),
+  id: z.string(),
+  name: z.string(),
+  bin: z.string(),
+  args: z.array(z.string()).catch([]),
+  registeredAt: z.number().catch(0),
+});
+export type RegisteredApp = z.infer<typeof registeredAppSchema>;
+
+function appFile(id: string): string {
+  return path.join(INTEROP_APPS_DIR, `${id}.json`);
+}
+
+export function appId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "app";
+}
+
+export function registerApp(app: Omit<RegisteredApp, "version" | "registeredAt">): void {
+  fs.mkdirSync(INTEROP_APPS_DIR, { recursive: true });
+  fs.writeFileSync(
+    appFile(app.id),
+    `${JSON.stringify({ version: APP_MANIFEST_VERSION, registeredAt: Date.now(), ...app }, null, 2)}\n`,
+  );
+}
+
+export function unregisterApp(id: string): boolean {
+  const file = appFile(id);
+  if (!fs.existsSync(file)) return false;
+  fs.rmSync(file, { force: true });
+  return true;
+}
+
+export function listApps(): RegisteredApp[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(INTEROP_APPS_DIR);
+  } catch {
+    return [];
+  }
+  const apps: RegisteredApp[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const parsed = registeredAppSchema.safeParse(readJson(path.join(INTEROP_APPS_DIR, name)));
+    if (!parsed.success || parsed.data.version > APP_MANIFEST_VERSION) continue;
+    if (!fs.existsSync(parsed.data.bin)) continue;
+    apps.push(parsed.data);
+  }
+  return apps.sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
This PR adds a feature to terminal-browser that allows it to communicate with other terminal-browser instances. This communication is used to allow multiple terminal browser instances to compose in a single terminal pane instead of opening a new pane in the same tab.

An example case this is useful is if you are using claude code and [terminal code](https://terminal-code.com/) side by side:

```
+---------------+---------------+
|  claude code  | terminal-code |
|               |               |
|               |               |
+---------------+---------------+
```

You then want to open `terminal-browser` (e.g. to open an html based plan, have the agent use a website, etc). Currently claude will open another pane to the right of itself

```
+---------------+-------+-------+
|  claude code  |       |       |
|               |       |       |
|               |       |       |
+---------------+-------+-------+
```

Especially on smaller displays like laptops, this terminal pane opens at an un-usable width, and causes lots of clutter

Now, in this example using this new communication feature, terminal-browser can ask terminal-code to create a new tab containing the website the user wants to open. This would result in terminal-code showing a tab bar with 2 tabs, one for the open terminal-code instance, and another with the tab of the website requested to be opened
```
+---------------+-----------------------+
|  claude code  | terminal-code         |
|               |          +            |
|               |    terminal-browser   |
|               |                       |
+---------------+-----------------------+
```
Demo:

https://github.com/user-attachments/assets/29e284e1-761c-49b8-991b-f07479cb6fd7

---

terminal-browser instances discover each other through a global registry that contains:
- statically all terminal-browser based apps on the computer
- the current running terminal-browser based apps


This global registry uses an agreed upon schema, which is how other terminal-browser instances are expected to parse the file content:

```
// ~/.local/share/terminal-browser-interop/apps/<id>.json
{
  version: string
  id: string;
  name: string;
  bin: string;
  args: string[];
  registeredAt: number;
};

// ~/.local/state/terminal-browser-interop/instances/<key>.json
 {
  version: string
  protocolVersions: number[];
  mode: "browser" | "app";
  pid: number;
  socket: string;
  startedAt: number;
};
```

`apps` contains a directory will registered applications. An application can be added to the registry by running:
`terminal-browser register-app --id ... --name ... --bin <binary path>`.

This should be ran by terminal-browser --app-mode applications to provide the best user experience, but a user is also able to manually register an terminal-browser based application.

Registered applications can be opened inside an existing terminal browser instance by searching with the application name when making a new tab.

`instances` contains a directory with running `terminal-browser` instances that can send and receive messages to each other. The `socket` field is a path to a unix socket that accepts and recv messages. The messaging protocol for this socket is defined as:

```
{
  cmd: "interop/1/open";
  requestId: string
  url?: string;   
  app?: {       
    name?: string;
    id: string;
    partition?: string;
    preload?: string; 
    mainScript?: string; 
  };
};

// sends back
{
 ok: true,
 requestId: string
 data: {
   tab: number
 }
} | 
{
  ok: false,
  requestId: string
  error: string
}
```


Before sending the message, you are able to verify the instance supports the protocol version based on the `instances` record field `protocolVersions: number[];` which contains an array of supported protocol major

The `app` field in the open request is required only when requesting a terminal-browser instance to open an application. 
```
    partition?: string;
    preload?: string; 
    mainScript?: string; 
```
Are configurations a normal terminal-browser --app-mode application can use, so it needs to be forwarded to terminal-browser if its to properly embed the application. 
```
    name?: string;
    id: string;
```
Name is displayed in the tab for the application. Id is the default value for the browser partition key, and used for misc. equality checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->