### PR TITLE
Visualize agent using browser

### DIFF
--- a/browser/src/registry.ts
+++ b/browser/src/registry.ts
@@ -38,6 +38,8 @@ export interface ControlHost {
   openTab(url?: string, cwd?: string): number;
   activateTab(id: number): boolean;
   closeTab(id: number): boolean;
+  agentTouch(id: number): boolean;
+  agentRelease(): void;
   tabs(): unknown;
   targets(): Promise<unknown>;
   viewport(): { width: number; height: number } | null;
@@ -185,6 +187,15 @@ export class Registry {
       case "close-tab": {
         if (request.tab === undefined) throw new Error("close-tab needs a tab id");
         if (!this.host.closeTab(request.tab)) throw new Error(`no tab ${request.tab}`);
+        return { ...this.record(), tabs: await this.host.targets() };
+      }
+      case "agent-touch": {
+        if (request.tab === undefined) throw new Error("agent-touch needs a tab id");
+        if (!this.host.agentTouch(request.tab)) throw new Error(`no tab ${request.tab}`);
+        return this.record();
+      }
+      case "agent-release": {
+        this.host.agentRelease();
         return { ...this.record(), tabs: await this.host.targets() };
       }
       default:

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -444,6 +444,8 @@ class Session {
         this.tabs.close(id);
         return true;
       },
+      agentTouch: (id) => this.tabs.touchAgentControl(id),
+      agentRelease: () => this.tabs.releaseAgentControl(),
       viewport: () =>
         this.root ? { width: this.root.info.width, height: this.root.info.height } : null,
       tabs: () => this.tabs.registryView(),

--- a/browser/src/session/tabs.ts
+++ b/browser/src/session/tabs.ts
@@ -21,6 +21,7 @@ export interface Tab {
   controller: BrowserController;
   targetId: string | null;
   app: TabApp | null;
+  agentControlAt: number | null;
 }
 
 export interface TabTarget {
@@ -31,6 +32,7 @@ export interface TabTarget {
   targetId: string | null;
   app?: TabApp | null;
   timeOrigin?: number | null;
+  agentControlled: boolean;
 }
 
 
@@ -54,10 +56,15 @@ export interface TabHost {
   requestRender(): void;
 }
 
+const parsedTtl = Number(process.env.TERMINAL_BROWSER_AGENT_CONTROL_MS);
+const AGENT_CONTROL_TTL_MS = Number.isFinite(parsedTtl) && parsedTtl > 0 ? parsedTtl : 20_000;
+const AGENT_CONTROL_SWEEP_MS = 500;
+
 export class TabManager {
   private tabs: Tab[] = [];
   private activeId = 0;
   private seq = 1;
+  private agentSweep: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private readonly host: TabHost,
@@ -89,6 +96,7 @@ export class TabManager {
       state: initialBrowserState(url),
       targetId: null,
       app: options.app ?? null,
+      agentControlAt: null,
     } as Tab;
     this.attachController(tab, url, activate, options);
     this.tabs.push(tab);
@@ -162,6 +170,61 @@ export class TabManager {
     return this.tabs.some((tab) => tab.id === id);
   }
 
+  touchAgentControl(id: number): boolean {
+    const tab = this.tabs.find((t) => t.id === id);
+    if (!tab) return false;
+    const fresh = tab.agentControlAt == null;
+    tab.agentControlAt = Date.now();
+    this.startAgentSweep();
+    if (fresh) {
+      this.host.onTabsChanged();
+      this.host.requestRender();
+    }
+    return true;
+  }
+
+  releaseAgentControl() {
+    this.stopAgentSweep();
+    let changed = false;
+    for (const tab of this.tabs) {
+      if (tab.agentControlAt == null) continue;
+      tab.agentControlAt = null;
+      changed = true;
+    }
+    if (!changed) return;
+    this.host.onTabsChanged();
+    this.host.requestRender();
+  }
+
+  private startAgentSweep() {
+    if (this.agentSweep) return;
+    this.agentSweep = setInterval(() => {
+      const cutoff = Date.now() - AGENT_CONTROL_TTL_MS;
+      let changed = false;
+      let remaining = false;
+      for (const tab of this.tabs) {
+        if (tab.agentControlAt == null) continue;
+        if (tab.agentControlAt < cutoff) {
+          tab.agentControlAt = null;
+          changed = true;
+        } else {
+          remaining = true;
+        }
+      }
+      if (!remaining) this.stopAgentSweep();
+      if (changed) {
+        this.host.onTabsChanged();
+        this.host.requestRender();
+      }
+    }, AGENT_CONTROL_SWEEP_MS);
+  }
+
+  private stopAgentSweep() {
+    if (!this.agentSweep) return;
+    clearInterval(this.agentSweep);
+    this.agentSweep = null;
+  }
+
   soleAppTab(): boolean {
     return this.tabs.length === 1 && this.tabs[0].app != null;
   }
@@ -186,6 +249,7 @@ export class TabManager {
       favicon: tab.app ? null : tab.state.favicon,
       active: tab.id === this.activeId,
       app: tab.app != null,
+      agentControlled: tab.agentControlAt != null,
     }));
   }
 
@@ -197,6 +261,7 @@ export class TabManager {
       active: tab.id === this.activeId,
       targetId: tab.targetId,
       app: tab.app,
+      agentControlled: tab.agentControlAt != null,
     }));
   }
 
@@ -212,6 +277,7 @@ export class TabManager {
           targetId: tab.targetId,
           app: tab.app,
           timeOrigin: await tab.controller.fingerprint(),
+          agentControlled: tab.agentControlAt != null,
         };
       }),
     );
@@ -222,6 +288,7 @@ export class TabManager {
   }
 
   stopAll() {
+    this.stopAgentSweep();
     for (const tab of this.tabs) tab.controller.stop();
     this.tabs = [];
     this.activeId = 0;

--- a/browser/src/ui/chrome.tsx
+++ b/browser/src/ui/chrome.tsx
@@ -16,8 +16,9 @@ import {
   ReviewToolbar,
 } from "./record-bar";
 import { TabStrip } from "./tab-strip";
-import { makeTheme } from "./theme";
+import { makeTheme, withAlpha } from "./theme";
 import type { Theme } from "./theme";
+import { usePulse } from "./pulse";
 import type { RecordView } from "../record/types";
 import type {
   ChromeActions,
@@ -79,6 +80,9 @@ export function Chrome({
 }) {
   const theme = useMemo(() => makeTheme(colors), [colors]);
   const progress = useProgress(!noOverlays && state.loading);
+  const agentActive =
+    !noOverlays && tabs.some((tab) => tab.active && tab.agentControlled);
+  const glowPulse = usePulse(agentActive);
   return (
     <Box
       style={{
@@ -110,7 +114,9 @@ export function Chrome({
         surface={pageSurface}
         actions={actions}
         interactive={!record?.canvas}
+        agentActive={agentActive}
       />
+      {agentActive && <AgentGlow layout={layout} theme={theme} intensity={glowPulse} />}
       {layout.devtools && (
         <DevtoolsPane
           layout={layout}
@@ -339,18 +345,114 @@ function seamRadius(radius: number, dock: "bottom" | "right" | null, side: "page
     : { topRight: radius, bottomRight: radius, topLeft: 0, bottomLeft: 0 };
 }
 
+const GLOW_PEAK_ALPHA = 190;
+
+function AgentGlow({
+  layout,
+  theme,
+  intensity,
+}: {
+  layout: ChromeLayout;
+  theme: Theme;
+  intensity: number;
+}) {
+  const dock = layout.devtools?.dock ?? null;
+  const page = layout.page;
+  const depth = Math.min(
+    Math.max(16, Math.round(layout.rem * 2.2)),
+    Math.floor(Math.min(page.width, page.height) / 2),
+  );
+  const base = layout.frame
+    ? seamRadius(Math.max(2, layout.rem * 0.55 - 1), dock, "page")
+    : 0;
+  const r =
+    typeof base === "number"
+      ? { topLeft: base, topRight: base, bottomRight: base, bottomLeft: base }
+      : base;
+  const level = (peak: number) =>
+    withAlpha(theme.accent, Math.round(GLOW_PEAK_ALPHA * intensity * peak));
+  const fade = (from: [number, number], to: [number, number]) => ({
+    from,
+    to,
+    stops: [
+      { at: 0, color: level(1) },
+      { at: 0.35, color: level(0.42) },
+      { at: 0.7, color: level(0.09) },
+      { at: 1, color: level(0) },
+    ],
+  });
+  const strip = (
+    key: string,
+    inset: { top: number; left: number },
+    width: number,
+    height: number,
+    cornerRadius: Record<string, number>,
+    axis: [[number, number], [number, number]],
+  ) => (
+    <Box
+      key={key}
+      style={{
+        position: "absolute",
+        inset,
+        width,
+        height,
+        cornerRadius,
+        background: fade(axis[0], axis[1]),
+      }}
+    />
+  );
+  return (
+    <>
+      {strip(
+        "top",
+        { top: page.y, left: page.x },
+        page.width,
+        depth,
+        { topLeft: r.topLeft, topRight: r.topRight },
+        [[0, 0], [0, 1]],
+      )}
+      {strip(
+        "bottom",
+        { top: page.y + page.height - depth, left: page.x },
+        page.width,
+        depth,
+        { bottomLeft: r.bottomLeft, bottomRight: r.bottomRight },
+        [[0, 1], [0, 0]],
+      )}
+      {strip(
+        "left",
+        { top: page.y, left: page.x },
+        depth,
+        page.height,
+        { topLeft: r.topLeft, bottomLeft: r.bottomLeft },
+        [[0, 0], [1, 0]],
+      )}
+      {strip(
+        "right",
+        { top: page.y, left: page.x + page.width - depth },
+        depth,
+        page.height,
+        { topRight: r.topRight, bottomRight: r.bottomRight },
+        [[1, 0], [0, 0]],
+      )}
+    </>
+  );
+}
+
 function BrowserTabContents({
   layout,
   theme,
   surface,
   actions,
   interactive,
+  agentActive,
 }: {
   layout: ChromeLayout;
   theme: Theme;
   surface: Surface;
   actions: ChromeActions;
   interactive: boolean;
+  agentActive: boolean;
 }) {
   const dock = layout.devtools?.dock ?? null;
   return (
@@ -363,7 +465,7 @@ function BrowserTabContents({
             width: layout.page.width + 2,
             height: layout.page.height + 2,
             cornerRadius: seamRadius(layout.rem * 0.55, dock, "page"),
-            border: { width: 1, color: theme.fieldBorder },
+            border: { width: 1, color: agentActive ? theme.accent : theme.fieldBorder },
           }}
         />
       )}

--- a/browser/src/ui/chrome.tsx
+++ b/browser/src/ui/chrome.tsx
@@ -345,7 +345,7 @@ function seamRadius(radius: number, dock: "bottom" | "right" | null, side: "page
     : { topRight: radius, bottomRight: radius, topLeft: 0, bottomLeft: 0 };
 }
 
-const GLOW_PEAK_ALPHA = 190;
+const GLOW_PEAK_ALPHA = 140;
 
 function AgentGlow({
   layout,
@@ -359,7 +359,7 @@ function AgentGlow({
   const dock = layout.devtools?.dock ?? null;
   const page = layout.page;
   const depth = Math.min(
-    Math.max(16, Math.round(layout.rem * 2.2)),
+    Math.max(12, Math.round(layout.rem * 1.6)),
     Math.floor(Math.min(page.width, page.height) / 2),
   );
   const base = layout.frame

--- a/browser/src/ui/pulse.ts
+++ b/browser/src/ui/pulse.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+const PERIOD_MS = 2800;
+const TICK_MS = 100;
+
+export function usePulse(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const timer = setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => clearInterval(timer);
+  }, [active]);
+  if (!active) return 0;
+  const phase = ((now % PERIOD_MS) / PERIOD_MS) * Math.PI * 2;
+  return 0.6 + 0.4 * (0.5 + 0.5 * Math.sin(phase));
+}

--- a/browser/src/ui/tab-strip.tsx
+++ b/browser/src/ui/tab-strip.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { Box, Image, Text } from "pixel-react";
 import { displayUrl } from "../url";
 import { Icon } from "./icons";
+import { usePulse } from "./pulse";
+import { mix, withAlpha } from "./theme";
 import type { Theme } from "./theme";
 import type { ChromeActions, TabRow } from "./types";
 
@@ -145,6 +147,7 @@ export function TabStrip({
   const [hovered, setHovered] = useState<number | null>(null);
   const activeLabel = displayUrl(url);
   const pointerIn = useRef(false);
+  const dotPulse = usePulse(tabs.some((tab) => tab.agentControlled && !tab.active));
   const label = (tab: TabRow) =>
     tab.active && !tab.app
       ? activeLabel || tab.title || "new tab"
@@ -257,6 +260,25 @@ export function TabStrip({
               >
                 <Icon icon="close" size={rem * 0.8} color={theme.muted} />
               </Box>
+            ) : tab.agentControlled && !tab.active && !ghost ? (
+              <Box
+                style={{
+                  width: slotW,
+                  height: slotW,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                }}
+              >
+                <Box
+                  style={{
+                    width: slotW * 0.5,
+                    height: slotW * 0.5,
+                    cornerRadius: slotW * 0.25,
+                    background: withAlpha(theme.accent, Math.round(255 * dotPulse)),
+                  }}
+                />
+              </Box>
             ) : tab.favicon ? (
               <Image
                 src={tab.favicon}
@@ -274,7 +296,14 @@ export function TabStrip({
             <Text
               style={{
                 fontSize: rem * 0.82,
-                color: tab.active && !ghost ? theme.fg : theme.muted,
+                color:
+                  tab.agentControlled && !ghost
+                    ? tab.active
+                      ? theme.accent
+                      : mix(theme.muted, theme.accent, 0.6)
+                    : tab.active && !ghost
+                      ? theme.fg
+                      : theme.muted,
                 wrap: false,
                 selectable: false,
                 flexShrink: 1,

--- a/browser/src/ui/types.ts
+++ b/browser/src/ui/types.ts
@@ -21,6 +21,7 @@ export interface TabRow {
   favicon: string | null;
   active: boolean;
   app: boolean;
+  agentControlled: boolean;
 }
 
 export interface PopupView {

--- a/cli/src/action.ts
+++ b/cli/src/action.ts
@@ -28,6 +28,7 @@ export interface ActionOptions {
   tabId?: number;
   targetId?: string;
   follow: boolean;
+  done: boolean;
   passthrough: string[];
 }
 
@@ -247,10 +248,17 @@ export async function actionCommand(terminal: Terminal | null, options: ActionOp
   const selection = await select(terminal, options);
   const { browser, tab } = selection;
 
+  if (options.done) {
+    const reply = await control(browser.socket, { cmd: "agent-release" });
+    process.stdout.write(`${JSON.stringify(reply, null, 2)}\n`);
+    return 0;
+  }
+
   if (options.passthrough.length === 0) {
     throw new Error("nothing to run — pass a command after --, e.g. terminal-browser action -- snapshot");
   }
   checkGuardrails(options.passthrough);
+  await control(browser.socket, { cmd: "agent-touch", tab: tab.id }).catch(() => {});
 
   const intercepted = await interceptTabLifecycle(selection, options.passthrough);
   if (intercepted !== null) {

--- a/cli/src/help.ts
+++ b/cli/src/help.ts
@@ -159,6 +159,7 @@ Examples:
   terminal-browser action -- click @e14
   terminal-browser action -- eval "document.title"
   terminal-browser action --browser 90107-1 --tab 2 -- fill @e3 "hello"
+  terminal-browser action done
 `,
   },
 };

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -210,15 +210,14 @@ function nextReply(socket: net.Socket, onLine: (reply: DaemonReply) => void): vo
 
 
 async function openSession(argv: string[], tty: string): Promise<{ socket: net.Socket; reply: DaemonReply }> {
-  const request = `${JSON.stringify({
+  const payload = {
     cmd: "open",
     tty,
     argv,
     env: process.env,
     cwd: process.cwd(),
-    build: browserBuildStamp(),
-  })}\n`;
-  const ask = (socket: net.Socket) =>
+  };
+  const ask = (socket: net.Socket, build: string | null) =>
     new Promise<DaemonReply>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error("daemon open timed out")), 20_000);
       nextReply(socket, (reply) => {
@@ -229,16 +228,20 @@ async function openSession(argv: string[], tty: string): Promise<{ socket: net.S
         clearTimeout(timer);
         reject(new Error("daemon closed the connection"));
       });
-      socket.write(request);
+      socket.write(`${JSON.stringify(build ? { ...payload, build } : payload)}\n`);
     });
   let socket = await daemonSocket();
-  let reply = await ask(socket);
+  let reply = await ask(socket, browserBuildStamp());
   if (reply.ok === false && reply.error === "stale") {
-    // the stale daemon steps aside when idle; give it a beat and respawn
     socket.destroy();
     await sleep(700);
     socket = await daemonSocket();
-    reply = await ask(socket);
+    reply = await ask(socket, browserBuildStamp());
+  }
+  if (reply.ok === false && reply.error === "stale") {
+    socket.destroy();
+    socket = await daemonSocket();
+    reply = await ask(socket, null);
   }
   return { socket, reply };
 }
@@ -748,8 +751,14 @@ async function main(): Promise<number> {
       tabId: takeTabFlag(own),
       targetId: takeFlag(own, "--target"),
       follow: takeBoolFlag(own, "--follow"),
+      done: false,
       passthrough,
     };
+    if (own[0] === "done") {
+      own.shift();
+      options.done = true;
+      if (passthrough.length > 0) fail("[PLACEHOLDER COPY]");
+    }
     if (own.length > 0) fail(`unexpected ${own[0]} — put agent-browser arguments after --`);
     return actionCommand((await currentTerminal()).terminal, options);
   }

--- a/engine/crates/pixel-core/src/canvas.rs
+++ b/engine/crates/pixel-core/src/canvas.rs
@@ -608,6 +608,50 @@ impl Canvas {
         }
     }
 
+    pub fn fill_rounded_rect_gradient(
+        &mut self,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        radius: [f32; 4],
+        gradient: &crate::style::LinearGradient,
+    ) {
+        if w <= 0.0 || h <= 0.0 || gradient.stops.is_empty() {
+            return;
+        }
+        if self.clipped_out(x, y, w, h) || self.occluded(x, y, w, h) {
+            return;
+        }
+        let point = |(fx, fy): (f32, f32)| tiny_skia::Point::from_xy(x + fx * w, y + fy * h);
+        let stops = gradient
+            .stops
+            .iter()
+            .map(|&(at, c)| {
+                tiny_skia::GradientStop::new(
+                    at.clamp(0.0, 1.0),
+                    tiny_skia::Color::from_rgba8(c[0], c[1], c[2], c[3]),
+                )
+            })
+            .collect();
+        let Some(shader) = tiny_skia::LinearGradient::new(
+            point(gradient.from),
+            point(gradient.to),
+            stops,
+            tiny_skia::SpreadMode::Pad,
+            tiny_skia::Transform::identity(),
+        ) else {
+            return;
+        };
+        let Some(path) = rounded_rect_path(x, y, w, h, radius) else {
+            return;
+        };
+        let mut paint = tiny_skia::Paint::default();
+        paint.shader = shader;
+        paint.anti_alias = true;
+        self.paint_path_with(&path, paint, None);
+    }
+
     fn blend_fill(&mut self, x: f32, y: f32, w: f32, h: f32, color: [u8; 4]) {
         if w <= 0.0 || h <= 0.0 {
             return;
@@ -918,6 +962,15 @@ impl Canvas {
         color: [u8; 4],
         stroke: Option<tiny_skia::Stroke>,
     ) {
+        self.paint_path_with(path, solid_paint(color), stroke);
+    }
+
+    fn paint_path_with(
+        &mut self,
+        path: &tiny_skia::Path,
+        paint: tiny_skia::Paint<'static>,
+        stroke: Option<tiny_skia::Stroke>,
+    ) {
         let (cx1, cy1, cx2, cy2) = self.clip_bounds();
         if cx1 == cx2 || cy1 == cy2 {
             return;
@@ -940,7 +993,7 @@ impl Canvas {
                 && bounds.bottom() + pad <= cy2 as f32);
         if !inside {
             tally(|s| &s.paths_clipped);
-            self.paint_path_clipped(path, color, stroke, (cx1, cy1, cx2, cy2), pad);
+            self.paint_path_clipped(path, paint, stroke, (cx1, cy1, cx2, cy2), pad);
             return;
         }
         let Some(mut pixmap) =
@@ -948,7 +1001,6 @@ impl Canvas {
         else {
             return;
         };
-        let paint = solid_paint(color);
         match stroke {
             None => pixmap.fill_path(
                 path,
@@ -970,7 +1022,7 @@ impl Canvas {
     fn paint_path_clipped(
         &mut self,
         path: &tiny_skia::Path,
-        color: [u8; 4],
+        paint: tiny_skia::Paint<'static>,
         stroke: Option<tiny_skia::Stroke>,
         clip: (u32, u32, u32, u32),
         pad: f32,
@@ -989,7 +1041,6 @@ impl Canvas {
         scratch.clear();
         scratch.resize(w as usize * h as usize * 4, 0);
         if let Some(mut pixmap) = tiny_skia::PixmapMut::from_bytes(&mut scratch, w, h) {
-            let paint = solid_paint(color);
             let shift = tiny_skia::Transform::from_translate(-(x1 as f32), -(y1 as f32));
             match stroke {
                 None => pixmap.fill_path(path, &paint, tiny_skia::FillRule::Winding, shift, None),
@@ -1314,5 +1365,24 @@ mod tests {
         let mut canvas = Canvas::new(2, 2);
         canvas.blend_mask(-1, -1, 3, 3, &[255; 9], [10, 20, 30, 255], 0, 0.0);
         assert_eq!(&canvas.pixels[0..4], &[10, 20, 30, 255]);
+    }
+
+    #[test]
+    fn gradient_fill_fades_along_its_axis_and_respects_the_silhouette() {
+        let mut canvas = Canvas::new(100, 100);
+        canvas.fill([255, 255, 255, 255]);
+        let gradient = crate::style::LinearGradient {
+            from: (0.0, 0.0),
+            to: (1.0, 0.0),
+            stops: vec![(0.0, [93, 156, 255, 200]), (1.0, [93, 156, 255, 0])],
+        };
+        canvas.fill_rounded_rect_gradient(10.0, 10.0, 60.0, 60.0, [12.0; 4], &gradient);
+        // over white, the red channel dips where the blue lands
+        let red = |x: u32, y: u32| canvas.pixels[((y * 100 + x) * 4) as usize];
+        assert!(red(11, 40) < 200, "start edge barely tinted: {}", red(11, 40));
+        assert!(red(11, 40) < red(30, 40), "{} !< {}", red(11, 40), red(30, 40));
+        assert!(red(30, 40) < red(60, 40), "{} !< {}", red(30, 40), red(60, 40));
+        assert_eq!(red(80, 40), 255, "painted outside the rect");
+        assert_eq!(red(11, 11), 255, "painted outside the rounded corner");
     }
 }

--- a/engine/crates/pixel-core/src/lib.rs
+++ b/engine/crates/pixel-core/src/lib.rs
@@ -45,7 +45,7 @@ pub use scrollbar::ScrollbarRects;
 pub use selection::{DocPos, DocSelection};
 pub use style::{
     Align, Border, BorderSide, Color, Dimension, Edges, FlexDirection, Inset, InsetValue, Justify,
-    Overflow, Position, ScrollbarStyle, SelectionMode, Style,
+    LinearGradient, Overflow, Paint, Position, ScrollbarStyle, SelectionMode, Style,
 };
 pub use terminal::{
     Event, Key, KeyEvent, KeyKind, Mods, Mouse, MouseButton, MouseKind, Terminal, TerminalColors,

--- a/engine/crates/pixel-core/src/menu.rs
+++ b/engine/crates/pixel-core/src/menu.rs
@@ -279,7 +279,7 @@ pub fn context_menu(
                         style: Style {
                             height: Dimension::Px(1.0),
                             margin: Edges::symmetric(0.0, separator_margin),
-                            background: Some(style.border),
+                            background: Some(crate::style::Paint::Solid(style.border)),
                             ..Style::default()
                         },
                         ..Desc::default()
@@ -335,7 +335,7 @@ pub fn context_menu(
             inset: Inset::top_left(x, y),
             flex_direction: FlexDirection::Column,
             padding: Edges::all(pad),
-            background: Some(style.background),
+            background: Some(crate::style::Paint::Solid(style.background)),
             corner_radius: [px * 0.5; 4],
             border: Some(Border::hairline(style.border)),
             ..Style::default()

--- a/engine/crates/pixel-core/src/paint.rs
+++ b/engine/crates/pixel-core/src/paint.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use crate::canvas::{Canvas, measure_marked, measure_text};
 use crate::image_cache::ImageStatus;
-use crate::style::{Color, Overflow};
+use crate::style::{Color, Overflow, Paint};
 use crate::text_input::{Mark, caret_width, offset_to_point};
 use crate::tree::{NodeId, PxRect, SlotKind, TextSpan, Tree};
 use crate::wrap::wrap_lines;
@@ -178,23 +178,32 @@ fn paint_node(
     let hovered = cursor.is_some_and(|(x, y)| visible.contains(x, y));
 
     let background = match (hovered, node.style.hover_background) {
-        (true, Some(bg)) => Some(bg),
-        _ => node.style.background,
+        (true, Some(bg)) => Some(Paint::Solid(bg)),
+        _ => node.style.background.clone(),
     };
     if background.is_some() || node.style.border.is_some() {
         if let Some(stats) = stats {
             stats.rect_count += background.is_some() as u64 + node.style.border.is_some() as u64;
         }
         timed(stats.as_mut().map(|s| &mut s.rects), || {
-            if let Some(bg) = background {
-                canvas.fill_rounded_rect(
+            match &background {
+                Some(Paint::Solid(bg)) => canvas.fill_rounded_rect(
                     rect.x,
                     rect.y,
                     rect.w,
                     rect.h,
                     node.style.corner_radius,
-                    bg,
-                );
+                    *bg,
+                ),
+                Some(Paint::Gradient(gradient)) => canvas.fill_rounded_rect_gradient(
+                    rect.x,
+                    rect.y,
+                    rect.w,
+                    rect.h,
+                    node.style.corner_radius,
+                    gradient,
+                ),
+                None => {}
             }
             if let Some(border) = node.style.border {
                 match border.uniform() {
@@ -923,7 +932,7 @@ mod tests {
             children: vec![Desc {
                 style: Style {
                     width: Dimension::Px(300.0),
-                    background: Some([20, 20, 20, 255]),
+                    background: Some(Paint::Solid([20, 20, 20, 255])),
                     ..Style::default()
                 },
                 text: Some("hello breakdown".into()),

--- a/engine/crates/pixel-core/src/style.rs
+++ b/engine/crates/pixel-core/src/style.rs
@@ -171,6 +171,19 @@ impl ScrollbarStyle {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct LinearGradient {
+    pub from: (f32, f32),
+    pub to: (f32, f32),
+    pub stops: Vec<(f32, Color)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Paint {
+    Solid(Color),
+    Gradient(LinearGradient),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Style {
     pub flex_direction: FlexDirection,
     pub flex_grow: f32,
@@ -189,7 +202,7 @@ pub struct Style {
     pub overflow: Overflow,
     pub justify_content: Option<Justify>,
     pub align_items: Option<Align>,
-    pub background: Option<Color>,
+    pub background: Option<Paint>,
     pub corner_radius: [f32; 4], // i dont love this, maybe deconstruct into sepearte api's
     pub border: Option<Border>,
     pub color: Option<Color>,

--- a/engine/crates/pixel-core/src/tree/tests.rs
+++ b/engine/crates/pixel-core/src/tree/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::canvas::Canvas;
 use crate::desc::Desc;
 use crate::paint::paint;
-use crate::style::{Align, Border, BorderSide, Edges, Position};
+use crate::style::{Align, Border, BorderSide, Edges, Paint, Position};
 
 static FONT_BYTES: &[u8] =
     include_bytes!("../../../../assets/fonts/JetBrainsMono-Regular.ttf");
@@ -103,7 +103,7 @@ fn exposes_rects_by_key_and_paints_background() {
             style: Style {
                 width: Dimension::Px(100.0),
                 height: Dimension::Px(40.0),
-                background: Some([10, 20, 30, 255]),
+                background: Some(Paint::Solid([10, 20, 30, 255])),
                 ..Style::default()
             },
             key: Some("panel".into()),
@@ -123,7 +123,7 @@ fn hover_swaps_background_under_cursor() {
         style: Style {
             width: Dimension::Px(10.0),
             height: Dimension::Px(10.0),
-            background: Some([1, 1, 1, 255]),
+            background: Some(Paint::Solid([1, 1, 1, 255])),
             hover_background: Some([9, 9, 9, 255]),
             ..Style::default()
         },
@@ -145,7 +145,7 @@ fn scroller(clickable_second: bool) -> Vec<Desc> {
             width: Dimension::Px(40.0),
             height: Dimension::Px(40.0),
             flex_shrink: 0.0,
-            background: Some(color),
+            background: Some(Paint::Solid(color)),
             ..Style::default()
         },
         key: Some(key.into()),
@@ -236,7 +236,7 @@ fn absolute_nodes_place_by_inset_and_sit_on_top() {
                     inset: crate::style::Inset::top_left(30.0, 40.0),
                     width: Dimension::Px(20.0),
                     height: Dimension::Px(10.0),
-                    background: Some([9, 9, 9, 255]),
+                    background: Some(Paint::Solid([9, 9, 9, 255])),
                     ..Style::default()
                 },
                 key: Some("float".into()),
@@ -1497,7 +1497,7 @@ fn unified_bands_stay_visible_over_child_backgrounds() {
             },
             Desc {
                 style: Style {
-                    background: Some([40, 40, 40, 255]),
+                    background: Some(Paint::Solid([40, 40, 40, 255])),
                     border: Some(Border::hairline([80, 80, 80, 255])),
                     padding: Edges::all(6.0),
                     ..Style::default()
@@ -1565,7 +1565,7 @@ fn placeholder_slot_fills_the_image_rect_until_the_decode_lands() {
                 key: Some("img".into()),
                 children: vec![Desc {
                     style: Style {
-                        background: Some([50, 50, 50, 255]),
+                        background: Some(Paint::Solid([50, 50, 50, 255])),
                         ..Style::default()
                     },
                     slot: Some(SlotKind::Placeholder),
@@ -1733,7 +1733,7 @@ fn static_text_marks_place_widgets_like_inputs() {
             style: Style {
                 width: Dimension::Px(40.0),
                 height: Dimension::Px(10.0),
-                background: Some([200, 30, 30, 255]),
+                background: Some(Paint::Solid([200, 30, 30, 255])),
                 ..Style::default()
             },
             mark: Some(9),

--- a/engine/crates/pixel-node/src/ops.rs
+++ b/engine/crates/pixel-node/src/ops.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
  */
 use pixel_core::{
     Align, Border, BorderSide, Color, Dimension, Edges, Engine, FlexDirection, Gutter,
-    HighlightArea, ImageProps, InputProps, Inset, InsetValue, Justify, LineCap, LineJoin, NodeId,
+    HighlightArea, ImageProps, InputProps, Inset, InsetValue, Justify, LineCap, LineJoin,
+    LinearGradient, NodeId, Paint,
     Overflow, Position, Props, ScrollbarStyle, SelectionMode, ShapeProps, ShapeStroke,
     SlotKind, Style, TextSpan, parse_path_data,
 };
@@ -419,6 +420,36 @@ impl ScrollbarDto {
 }
 
 #[derive(Deserialize)]
+struct GradientStopDto {
+    at: f32,
+    color: Color,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PaintDto {
+    Solid(Color),
+    Gradient {
+        from: (f32, f32),
+        to: (f32, f32),
+        stops: Vec<GradientStopDto>,
+    },
+}
+
+impl PaintDto {
+    fn into_paint(self) -> Paint {
+        match self {
+            PaintDto::Solid(color) => Paint::Solid(color),
+            PaintDto::Gradient { from, to, stops } => Paint::Gradient(LinearGradient {
+                from,
+                to,
+                stops: stops.into_iter().map(|s| (s.at, s.color)).collect(),
+            }),
+        }
+    }
+}
+
+#[derive(Deserialize)]
 #[serde(untagged)]
 enum CornerRadiusDto {
     Uniform(f32),
@@ -469,7 +500,7 @@ struct StyleDto {
     overflow: Option<String>,
     justify_content: Option<String>,
     align_items: Option<String>,
-    background: Option<Color>,
+    background: Option<PaintDto>,
     corner_radius: Option<CornerRadiusDto>,
     border: Option<BorderDto>,
     color: Option<Color>,
@@ -572,7 +603,7 @@ impl StyleDto {
                 "stretch" => Some(Align::Stretch),
                 _ => None,
             }),
-            background: self.background,
+            background: self.background.map(PaintDto::into_paint),
             corner_radius: self.corner_radius.map_or([0.0; 4], CornerRadiusDto::into_radii),
             border: self.border.map(BorderDto::into_border),
             color: self.color,

--- a/engine/packages/pixel-react/src/styles.ts
+++ b/engine/packages/pixel-react/src/styles.ts
@@ -30,6 +30,17 @@ export interface ScrollbarStyle {
 
 export type BorderSide = [width: number, color: Color];
 
+export interface GradientStop {
+  at: number;
+  color: Color;
+}
+
+export interface LinearGradient {
+  from: [number, number];
+  to: [number, number];
+  stops: GradientStop[];
+}
+
 export type Border =
   | { width: number; color: Color }
   | { top?: BorderSide; right?: BorderSide; bottom?: BorderSide; left?: BorderSide };
@@ -52,7 +63,7 @@ export interface Style {
   overflow?: "visible" | "hidden" | "scroll";
   justifyContent?: "start" | "center" | "end" | "space-between";
   alignItems?: "start" | "center" | "end" | "stretch";
-  background?: Color;
+  background?: Color | LinearGradient;
   cornerRadius?:
     | number
     | { topLeft?: number; topRight?: number; bottomRight?: number; bottomLeft?: number };
@@ -91,6 +102,15 @@ export function parseColor(color: Color | undefined): Rgba | undefined {
   return [int(0), int(2), int(4), hex.length === 8 ? int(6) : 255];
 }
 
+function serializePaint(paint: Color | LinearGradient): unknown {
+  if (Array.isArray(paint) || typeof paint === "string") return parseColor(paint);
+  return {
+    from: paint.from,
+    to: paint.to,
+    stops: paint.stops.map((stop) => ({ at: stop.at, color: parseColor(stop.color) })),
+  };
+}
+
 function serializeBorder(border: Border): Record<string, unknown> {
   if ("width" in border) {
     return { width: border.width, color: parseColor(border.color) };
@@ -123,7 +143,7 @@ export function serializeStyle(style: Style): Record<string, unknown> {
     overflow: style.overflow,
     justifyContent: style.justifyContent,
     alignItems: style.alignItems,
-    background: parseColor(style.background),
+    background: style.background === undefined ? undefined : serializePaint(style.background),
     cornerRadius: style.cornerRadius,
     border: style.border && serializeBorder(style.border),
     color: parseColor(style.color),

--- a/skill/terminal-browser/SKILL.template.md
+++ b/skill/terminal-browser/SKILL.template.md
@@ -16,4 +16,12 @@ tab ids the other commands take.
 tab that is already open. It targets this terminal tab's browser and its active
 tab unless you select another one.
 
+When you use the terminal-browser action sub command, the user will visually
+see in the browser tab an indication that you are acting on the browser tab. This
+will automatically hide after a preset duration, where the countdown resets
+everytime terminal-browser action is used. But its a much better experience
+for the user if after the last time you plan to use terminal-browser action you
+run terminal-browser action done, which immediately clears the indication
+that you are using the browser tab
+
 ## Command reference


### PR DESCRIPTION
This PR adds a visualization to browser tabs when being controlled by an agent:


https://github.com/user-attachments/assets/7d2b36c7-e7ea-41d7-a9db-ed0bbe57a015




The motivation is it's unclear when an agent is controlling a browser tab, and it can confuse the agent if you interact with the browser tab when the agent is also using it.

---
Whenever an agent calls `terminal-browser action` on a browser tab, we mark that browser tab as being controlled by an agent. There is a 20s duration the visualization shows, and resets every time an agent uses the browser. The agent can also explicitly call `terminal-browser action done` to indicate its no longer using the browser tab anymore.

The visualization is powered by a new API in the graphics engine that allows us to display a gradient as a background color for a `<Box/>` which is powered by tiny skia's gradient shader
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zenbu-labs/terminal-browser/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->