### PR TITLE
feat/fix/perf: explicit headless mode, browser window title, inline kitty chunks, lifecycle fixes

### DIFF
--- a/browser/src/daemon.ts
+++ b/browser/src/daemon.ts
@@ -66,6 +66,7 @@ export async function runDaemon(cdpPort: number | null): Promise<void> {
   const server = net.createServer((connection) => {
     let key: string | null = null;
     let session: SessionHandle | null = null;
+    let openReplied = false;
     const reply = (value: unknown) => {
       try {
         connection.write(`${JSON.stringify(value)}\n`);
@@ -111,8 +112,10 @@ export async function runDaemon(cdpPort: number | null): Promise<void> {
               cdpPort,
               onClose: (code) => {
                 sessions.delete(sessionKey);
-                reply({ event: "closed", code });
-                connection.end();
+                if (openReplied) {
+                  reply({ event: "closed", code });
+                  connection.end();
+                }
                 scheduleIdleExit();
               },
             });
@@ -122,8 +125,24 @@ export async function runDaemon(cdpPort: number | null): Promise<void> {
             scheduleIdleExit();
             return;
           }
-          sessions.set(sessionKey, session);
-          reply({ ok: true, session: sessionKey, pid: process.pid });
+          const opening = session;
+          sessions.set(sessionKey, opening);
+          void opening.ready.then(
+            () => {
+              if (session !== opening || !sessions.has(sessionKey)) return;
+              openReplied = true;
+              reply({ ok: true, session: sessionKey, pid: process.pid });
+            },
+            (error) => {
+              sessions.delete(sessionKey);
+              reply({
+                ok: false,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              connection.end();
+              scheduleIdleExit();
+            },
+          );
         } else if (message.cmd === "resize") {
           session?.nudgeResize();
         } else if (message.cmd === "close") {

--- a/browser/src/main.tsx
+++ b/browser/src/main.tsx
@@ -12,6 +12,9 @@ app.commandLine.appendSwitch("disable-renderer-backgrounding");
 app.commandLine.appendSwitch("disable-background-timer-throttling");
 app.commandLine.appendSwitch("disable-backgrounding-occluded-windows");
 
+if (process.platform === "linux" && process.env.TERMINAL_BROWSER_HEADLESS === "1") {
+  app.commandLine.appendSwitch("ozone-platform", "headless");
+}
 if (process.env.TERMINAL_BROWSER_DISABLE_GPU === "1") {
   app.commandLine.appendSwitch("disable-gpu");
 }

--- a/browser/src/page/controller.ts
+++ b/browser/src/page/controller.ts
@@ -192,7 +192,7 @@ export class BrowserController {
     this.window.webContents.on("did-stop-loading", () => this.updateNavigation(false));
     this.window.webContents.on("did-navigate", (_event, url) => {
       if (urlHost(url) !== urlHost(this.state.url)) this.updateState({ favicon: null });
-      this.updateNavigation(this.state.loading, url);
+      this.updateNavigation(this.state.loading, url, "");
     });
     this.window.webContents.on("page-favicon-updated", (_event, favicons) => {
       void this.loadFavicon(favicons);
@@ -570,9 +570,14 @@ export class BrowserController {
     if (file && seq === this.faviconSeq) this.updateState({ favicon: file });
   }
 
-  private updateNavigation(loading: boolean, url = this.window.webContents.getURL()) {
+  private updateNavigation(
+    loading: boolean,
+    url = this.window.webContents.getURL(),
+    title = this.state.title,
+  ) {
     this.updateState({
       url,
+      title,
       loading,
       canGoBack: this.window.webContents.navigationHistory.canGoBack(),
       canGoForward: this.window.webContents.navigationHistory.canGoForward(),

--- a/browser/src/page/paint.ts
+++ b/browser/src/page/paint.ts
@@ -76,9 +76,14 @@ function presentShmFrame(
     if (info.pixelFormat !== "bgra") return false;
     if (info.contentRect.x !== 0 || info.contentRect.y !== 0) return false;
     const update = info.metadata.captureUpdateRect;
-    if (update && update.width <= 0 && update.height <= 0 && !wholeSurface) return false;
     const damage =
-      wholeSurface || dirtyRect.width <= 0 || dirtyRect.height <= 0 ? undefined : dirtyRect;
+      wholeSurface
+        ? undefined
+        : update && update.width > 0 && update.height > 0
+          ? update
+          : dirtyRect.width > 0 && dirtyRect.height > 0
+            ? dirtyRect
+            : undefined;
     try {
       surface.present({
         shm: {

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -44,7 +44,7 @@ import type {
   PageMenuView,
   PopupView,
 } from "../ui/types";
-import { normalizeUrl, searchOrUrl } from "../url";
+import { displayUrl, normalizeUrl, searchOrUrl } from "../url";
 import { fuzzyScore } from "./fuzzy";
 import { bindingLabel, defaultKeys, isRecordKey, listStep, matchesBinding, parseKeyBindings, recordKeyLabel } from "./keybindings";
 import type { KeyBinding } from "./keybindings";
@@ -198,7 +198,6 @@ function matchApps(apps: RegisteredApp[], query: string): RegisteredApp[] {
 class Session {
   private readonly ctx: SessionContext;
   private readonly terminal: Terminal | null;
-  private readonly marker: string;
   private ownPane: Pane | null = null;
   private finding: Promise<Pane | null> | null = null;
   private readonly argv: string[];
@@ -271,6 +270,7 @@ class Session {
     selectionText: string;
   } | null = null;
   private sentCursor: string | null = null;
+  private sentTerminalTitle: string | null = null;
 
   private findOpen = false;
   private urlEditOpen = false;
@@ -291,7 +291,6 @@ class Session {
   constructor(ctx: SessionContext) {
     this.ctx = ctx;
     this.terminal = detect(ctx.env);
-    this.marker = `terminal-browser:${ctx.key}`;
     this.argv = ctx.argv;
     this.hideToolbar = this.argv.includes("--no-toolbar");
     this.noFrame = this.argv.includes("--no-frame");
@@ -345,6 +344,7 @@ class Session {
           this.syncDevtoolsLayout();
           this.syncCursor();
           this.registry?.update();
+          this.emitTerminalTitle(this.tabs.activeState ?? this.fallbackState);
         },
         onDevtoolsChanged: () => this.syncDevtoolsLayout(),
         onDevtoolsAction: (action) => {
@@ -365,6 +365,7 @@ class Session {
         onActiveState: (state, urlChanged) => {
           if (urlChanged) rememberUrl(state.url);
           this.registry?.update();
+          this.emitTerminalTitle(state);
         },
         onCursorChanged: () => this.syncCursor(),
         requestRender: () => this.render(),
@@ -379,7 +380,6 @@ class Session {
     if (process.platform === "darwin") app.dock?.hide();
     await this.loadDevtoolsSettings();
     if (this.shuttingDown) throw new Error("session closed during startup");
-    if (!this.ctx.tty) process.stdout.write(`\x1b]2;${this.marker}\x07`);
     this.displayScale = this.hostDisplayScale();
     this.root = createRoot({
       tty: this.ctx.tty,
@@ -477,6 +477,14 @@ class Session {
     this.registry.setCdpPort(this.ctx.cdpPort);
     void this.findOwnPane();
     this.render();
+  }
+
+  private emitTerminalTitle(state: BrowserState) {
+    if (this.shuttingDown) return;
+    const title = state.title || displayUrl(state.url);
+    if (!title || title === this.sentTerminalTitle) return;
+    this.root?.setTerminalTitle(title);
+    this.sentTerminalTitle = title;
   }
 
   private findOwnPane(): Promise<Pane | null> {

--- a/browser/src/session/session.tsx
+++ b/browser/src/session/session.tsx
@@ -72,11 +72,29 @@ export interface SessionHandle {
 }
 
 export function createSession(ctx: SessionContext): SessionHandle {
-  const session = new Session(ctx);
-  const ready = session.start().catch((error) => {
-    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
-    session.shutdown(1);
+  let startupSettled = false;
+  let rejectClosed: (error: Error) => void = () => {};
+  const closed = new Promise<never>((_, reject) => {
+    rejectClosed = reject;
   });
+  const session = new Session({
+    ...ctx,
+    onClose: (code) => {
+      if (!startupSettled) {
+        rejectClosed(new Error(`session closed with code ${code} before startup completed`));
+      }
+      ctx.onClose(code);
+    },
+  });
+  const ready = Promise.race([session.start(), closed])
+    .then(() => {
+      startupSettled = true;
+    })
+    .catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+      session.shutdown(1);
+      throw error;
+    });
   return {
     ready,
     close: (code = 0) => session.shutdown(code),
@@ -357,8 +375,10 @@ class Session {
 
   async start(): Promise<void> {
     if (this.socksPort) await routeThroughSocksProxy(this.partition, this.socksPort);
+    if (this.shuttingDown) throw new Error("session closed during startup");
     if (process.platform === "darwin") app.dock?.hide();
     await this.loadDevtoolsSettings();
+    if (this.shuttingDown) throw new Error("session closed during startup");
     if (!this.ctx.tty) process.stdout.write(`\x1b]2;${this.marker}\x07`);
     this.displayScale = this.hostDisplayScale();
     this.root = createRoot({
@@ -400,8 +420,13 @@ class Session {
         this.shutdown(error ? 1 : 0);
       },
     });
+    if (this.shuttingDown) {
+      this.root.stop();
+      throw new Error("session closed during startup");
+    }
     initOffscreenMode(this.root.sharedTextures);
     this.fontId = await this.root.registerFont(bundledFontPath());
+    if (this.shuttingDown) throw new Error("session closed during startup");
     this.applyKeyBindings(this.root.info.kittyKeyboard);
     this.popupSurface = this.root.createSurface();
     this.devtoolsSurface = this.root.createSurface();

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -108,8 +108,16 @@ function browserLaunchCommand(argv: string[]): { command: string[]; cwd: string 
   }
   // headless ozone reports a 1x1 screen unless told otherwise:
   // https://source.chromium.org/chromium/chromium/src/+/refs/tags/150.0.7871.212:ui/ozone/platform/headless/headless_screen.cc;l=37-46
-  if (process.platform === "linux" && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
-    argv = [...argv, "--ozone-platform=headless", "--screen-info={8192x8192}"];
+  if (
+    process.platform === "linux" &&
+    (process.env.TERMINAL_BROWSER_HEADLESS === "1" ||
+      (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY))
+  ) {
+    argv = [
+      ...argv,
+      "--ozone-platform=headless",
+      "--screen-info={8192x8192}",
+    ];
   }
   ensureDataDir();
   const logDir = LOGS_DIR;

--- a/engine/crates/pixel-core/src/engine/compositor.rs
+++ b/engine/crates/pixel-core/src/engine/compositor.rs
@@ -49,6 +49,7 @@ pub struct Compositor {
     pub relayout: bool,
     panes: [usize; 2],
     divider_hover: bool,
+    last_divider: Option<(u32, bool)>,
 }
 
 impl Compositor {
@@ -63,6 +64,7 @@ impl Compositor {
             relayout: true,
             panes: [0, 1],
             divider_hover: false,
+            last_divider: None,
         }
     }
 
@@ -175,12 +177,25 @@ impl Compositor {
         self.apply_layout(false)
     }
 
+    fn divider_state(&self) -> Option<(u32, bool)> {
+        self.divider_x()
+            .map(|x| (x, self.divider_hover || self.divider_drag))
+    }
+
+    pub(crate) fn compositor_changed(&self) -> bool {
+        self.last_divider != self.divider_state()
+    }
+
     pub(crate) fn compose(&mut self, painted: &[(usize, Rect)], whole_frame: bool) {
         let resized = (self.frame.width, self.frame.height) != self.window;
         if resized {
             self.frame = Canvas::new(self.window.0, self.window.1);
         }
-        let everything = resized || whole_frame || std::mem::take(&mut self.relayout);
+        let divider = self.divider_state();
+        let everything = resized
+            || whole_frame
+            || self.last_divider != divider
+            || std::mem::take(&mut self.relayout);
         for view in self.active_views() {
             let size = self.views[view].size;
             let rect = if everything {
@@ -199,6 +214,7 @@ impl Compositor {
             blit(frame, canvas, origin, rect);
         }
         self.draw_divider();
+        self.last_divider = divider;
     }
 
     fn draw_divider(&mut self) {
@@ -256,4 +272,24 @@ fn blit(dst: &mut Canvas, src: &Canvas, origin_x: u32, region: Rect) {
         },
         |(), ()| (),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn divider_state_change_requires_composition() {
+        let mut comp = Compositor::new((400, 20));
+        comp.set_split(Some(0.5));
+        comp.apply_layout(false);
+        comp.compose(&[], true);
+        comp.dirty = false;
+
+        assert!(!comp.compositor_changed());
+        comp.divider_drag = true;
+        assert!(comp.compositor_changed());
+        comp.compose(&[], false);
+        assert!(!comp.compositor_changed());
+    }
 }

--- a/engine/crates/pixel-core/src/engine/mod.rs
+++ b/engine/crates/pixel-core/src/engine/mod.rs
@@ -917,6 +917,12 @@ impl Engine {
         Ok(())
     }
 
+    pub fn set_terminal_title(&mut self, title: &str) {
+        if let Err(error) = self.term.set_terminal_title(title) {
+            logging::warn("engine", format!("terminal title write failed: {error}"));
+        }
+    }
+
     pub fn set_clipboard(&mut self, text: &str) {
         if let Err(error) = self.term.set_clipboard(text) {
             logging::warn("engine", format!("clipboard write failed: {error}"));

--- a/engine/crates/pixel-core/src/engine/mod.rs
+++ b/engine/crates/pixel-core/src/engine/mod.rs
@@ -964,6 +964,7 @@ impl Engine {
 
     fn draws_something(&self) -> bool {
         self.comp.dirty
+            || self.comp.compositor_changed()
             || self.comp.active_views().iter().any(|&i| {
                 let view = &self.comp.views[i];
                 view.tree.dirty()
@@ -996,7 +997,8 @@ impl Engine {
                 }
             })
             .collect();
-        if work.is_empty() && !self.comp.dirty {
+        let compositor_dirty = self.comp.dirty || self.comp.compositor_changed();
+        if work.is_empty() && !compositor_dirty {
             return Ok(());
         }
         crate::profiler::span("frame", || -> io::Result<()> {
@@ -1040,7 +1042,7 @@ impl Engine {
                 self.comp.dirty = true;
             }
             crate::profiler::set_view(0);
-            if !self.comp.dirty {
+            if painted.is_empty() && !compositor_dirty {
                 return Ok(());
             }
             self.compose(&painted);

--- a/engine/crates/pixel-core/src/kitty.rs
+++ b/engine/crates/pixel-core/src/kitty.rs
@@ -96,12 +96,11 @@ pub(crate) fn kitty_transmit_placed(
         miniz_oxide::deflate::compress_to_vec_zlib(rgba, 1)
     });
     let payload = crate::profiler::span("kitty.base64", || BASE64.encode(&compressed));
-    let chunks: Vec<&[u8]> = payload.as_bytes().chunks(KITTY_CHUNK_SIZE).collect();
-    let last = chunks.len() - 1;
+    let last = payload.len().div_ceil(KITTY_CHUNK_SIZE) - 1;
 
     let mut out = Vec::new();
     let mut seq = Vec::new();
-    for (i, chunk) in chunks.iter().enumerate() {
+    for (i, chunk) in payload.as_bytes().chunks(KITTY_CHUNK_SIZE).enumerate() {
         let more = u8::from(i != last);
         seq.clear();
         seq.extend_from_slice(b"\x1b_G");

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -1181,7 +1181,8 @@ impl FrameFile {
     }
 
     pub(crate) fn write(&mut self, data: &[u8]) {
-        unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), self.map.as_ptr(), self.len) };
+        assert_eq!(data.len(), self.len);
+        unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), self.map.as_ptr(), data.len()) };
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -1944,6 +1945,16 @@ mod tests {
 
         drop(file);
         assert!(!path.exists(), "the frame file outlived the terminal");
+    }
+
+    #[test]
+    #[should_panic]
+    fn frame_file_rejects_oversized_writes() {
+        let path =
+            std::env::temp_dir().join(format!("tb-frame-length-test-{}.rgba", std::process::id()));
+        let mut file = FrameFile::create(path, 8).unwrap();
+
+        file.write(&[0; 9]);
     }
 
     #[test]

--- a/engine/crates/pixel-core/src/terminal.rs
+++ b/engine/crates/pixel-core/src/terminal.rs
@@ -333,6 +333,30 @@ impl SessionEnv {
     }
 }
 
+const TERMINAL_TITLE_MAX_BYTES: usize = 1024;
+
+fn terminal_title_sequence(title: &str) -> Vec<u8> {
+    let mut sequence = Vec::with_capacity(title.len().min(TERMINAL_TITLE_MAX_BYTES) + 6);
+    sequence.extend_from_slice(b"\x1b]2;");
+    let mut payload_bytes = 0;
+    for character in title.chars() {
+        let safe = if character.is_control() {
+            ' '
+        } else {
+            character
+        };
+        let mut encoded = [0; 4];
+        let encoded = safe.encode_utf8(&mut encoded).as_bytes();
+        if payload_bytes + encoded.len() > TERMINAL_TITLE_MAX_BYTES {
+            break;
+        }
+        sequence.extend_from_slice(encoded);
+        payload_bytes += encoded.len();
+    }
+    sequence.extend_from_slice(b"\x1b\\");
+    sequence
+}
+
 impl Terminal {
     pub fn new(wrapper: Wrapper, env: SessionEnv) -> io::Result<Self> {
         Self::with_handle(
@@ -1029,6 +1053,11 @@ impl Terminal {
         }
         self.io.out()
             .write_all(format!("\x1b]22;{shape}\x1b\\").as_bytes())?;
+        self.io.out().flush()
+    }
+
+    pub fn set_terminal_title(&mut self, title: &str) -> io::Result<()> {
+        self.io.out().write_all(&terminal_title_sequence(title))?;
         self.io.out().flush()
     }
 
@@ -1911,6 +1940,20 @@ fn parse_cell_size_report(buf: &[u8]) -> Option<(u32, u32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terminal_title_replaces_controls_without_splitting_utf8() {
+        let title = format!("A\u{1b}\u{7f}\u{85}{}é", "x".repeat(1019));
+        let sequence = terminal_title_sequence(&title);
+        assert!(sequence.starts_with(b"\x1b]2;"));
+        assert!(sequence.ends_with(b"\x1b\\"));
+        let payload = &sequence[4..sequence.len() - 2];
+        assert_eq!(payload.len(), 1023);
+        assert_eq!(
+            std::str::from_utf8(payload).unwrap(),
+            format!("A   {}", "x".repeat(1019))
+        );
+    }
 
     #[test]
     fn parses_probe_replies() {

--- a/engine/crates/pixel-node/src/lib.rs
+++ b/engine/crates/pixel-node/src/lib.rs
@@ -12,7 +12,7 @@ mod record;
 mod shm;
 mod surface;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread::JoinHandle;
@@ -279,13 +279,19 @@ pub(crate) fn colors_json(colors: &TerminalColors) -> serde_json::Value {
 }
 
 
+enum EngineCommand {
+    ApplyOps(String),
+    Stop,
+}
+
 #[napi]
 pub struct PixelEngine {
     engine: Option<Engine>,
     info: String,
-    tx: Sender<String>,
-    rx: Option<Receiver<String>>,
+    tx: Sender<EngineCommand>,
+    rx: Option<Receiver<EngineCommand>>,
     waker: Waker,
+    terminal_title: Arc<Mutex<Option<String>>>,
     surfaces: Arc<SurfaceMailbox>,
     captures: capture::Registry,
     stop: Arc<AtomicBool>,
@@ -338,6 +344,7 @@ impl PixelEngine {
             tx,
             rx: Some(rx),
             waker,
+            terminal_title: Arc::new(Mutex::new(None)),
             // who even uses you tho
             surfaces: Arc::new(SurfaceMailbox::default()),
             captures: capture::Registry::default(),
@@ -356,9 +363,23 @@ impl PixelEngine {
      */
     #[napi]
     pub fn apply_ops(&self, ops: String) -> Result<()> {
-        let _ = self.tx.send(ops);
+        let _ = self.tx.send(EngineCommand::ApplyOps(ops));
         self.waker.wake();
         Ok(())
+    }
+
+    #[napi]
+    pub fn set_terminal_title(&self, title: String) {
+        let mut pending = self
+            .terminal_title
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if self.stop.load(Ordering::Acquire) {
+            return;
+        }
+        *pending = Some(title);
+        drop(pending);
+        self.waker.wake();
     }
 
     #[napi]
@@ -502,6 +523,7 @@ impl PixelEngine {
             .take()
             .ok_or_else(|| Error::from_reason("engine already started"))?;
         let stop = self.stop.clone();
+        let terminal_title = self.terminal_title.clone();
         let surfaces = self.surfaces.clone();
         let cell = SendEngine(engine);
         self.thread = Some(std::thread::spawn(move || {
@@ -513,16 +535,17 @@ impl PixelEngine {
                 .map(|view| IdMap::new(engine.comp.views[view].tree.root()))
                 .collect();
             let mut autoprofile = Autoprofile::from_env(&mut engine);
-            let exit_error = loop {
+            let exit_error = 'run: loop {
                 let events = match engine.pump(None) {
                     Ok(events) => events,
                     Err(e) => break Some(e.to_string()),
                 };
                 autoprofile.tick(&mut engine);
-                if stop.load(Ordering::Relaxed) {
-                    break None;
-                }
-                while let Ok(cmd) = rx.try_recv() {
+                while let Ok(command) = rx.try_recv() {
+                    let cmd = match command {
+                        EngineCommand::ApplyOps(cmd) => cmd,
+                        EngineCommand::Stop => break 'run None,
+                    };
                     let outcome = apply_ops(&mut engine, &mut ids, &cmd);
                     if let Some(message) = outcome.error {
                         pixel_core::logging::error("bridge", message.clone());
@@ -535,6 +558,15 @@ impl PixelEngine {
                     for reply in outcome.replies {
                         dispatch_to_node.call(Ok(reply), ThreadsafeFunctionCallMode::NonBlocking);
                     }
+                }
+                let title = terminal_title
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .take();
+                if let Some(title) = title
+                    && !stop.load(Ordering::Acquire)
+                {
+                    engine.set_terminal_title(&title);
                 }
                 for event in &events {
                     if let Some(json) = event_json(event, &engine, &ids) {
@@ -567,7 +599,7 @@ impl PixelEngine {
                 }
             };
             drop(engine);
-            if !stop.load(Ordering::Relaxed) {
+            if !stop.load(Ordering::Acquire) {
                 let exit = json!({ "type": "exit", "error": exit_error });
                 dispatch_to_node.call(
                     Ok(exit.to_string()),
@@ -580,7 +612,13 @@ impl PixelEngine {
 
     #[napi]
     pub fn stop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
+        self.stop.store(true, Ordering::Release);
+        let _ = self
+            .terminal_title
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+        let _ = self.tx.send(EngineCommand::Stop);
         self.waker.wake();
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();

--- a/engine/packages/pixel-react/src/index.ts
+++ b/engine/packages/pixel-react/src/index.ts
@@ -184,6 +184,7 @@ export interface PixelRoot {
   // nudge resize is a ridiculous api
   nudgeResize(): void;
   setPointerShape(shape: string): void;
+  setTerminalTitle(title: string): void;
   setKeyCapture(keys: string[]): void;
   requestClipboardImage(): void;
   setClipboard(text: string): void;
@@ -656,6 +657,9 @@ export function createRoot(options: RootOptions = {}): PixelRoot {
     setPointerShape(shape: string) {
       bridge.push(APP_VIEW, { op: "setPointerShape", shape });
       bridge.flush();
+    },
+    setTerminalTitle(title: string) {
+      bridge.engine.setTerminalTitle(title);
     },
     setKeyCapture(keys: string[]) {
       bridge.push(APP_VIEW, { op: "setKeyCapture", keys });

--- a/engine/packages/pixel-react/src/native.ts
+++ b/engine/packages/pixel-react/src/native.ts
@@ -38,6 +38,7 @@ export interface NativeEngine {
   captureFrame(captureId: number, index: number): Buffer;
   releaseCapture(captureId: number): void;
   setKeyEventTypes(enabled: boolean): void;
+  setTerminalTitle(title: string): void;
   start(callback: (err: unknown, event: string) => void): void;
   stop(): void;
 }


### PR DESCRIPTION
## changes & motivation
- *explicit `TERMINAL_BROWSER_HEADLESS=1`*: right now, headless is only enabled if you have no display. a machine with a working display might need to run a headless instance.
- *browser tab title `->` terminal window title*: helps show current browser tab amongst terminal tabs.
- *inline kitty chunks*: remove intermediate chunk-pointer allocation, up to ~10% measured perf increase on "busy" frames.
---
- session daemon previously reported ready before waiting for the browser to initialize.
- fallback to electron `dirtyRect` after trying `captureUpdateRect` and use unbounded damage when neither is valid.
- hovering or dragging the divider between UI & devtools could occur without repainting the webpage.
- validate `FrameFile` writes before doing unsafe `mmap-copy`.

## verification
build & tests passed, tested on linux + kitty/ghostty.