### PR TITLE
Grant local-network-access permission

### DIFF
--- a/browser/src/page/browser-session.ts
+++ b/browser/src/page/browser-session.ts
@@ -19,6 +19,7 @@ const GRANTED = new Set([
   "pointerLock",
   "clipboard-sanitized-write",
   "midi",
+  "local-network-access",
 ]);
 
 const configured = new WeakSet<Session>();


### PR DESCRIPTION
## Summary
- Adds `local-network-access` to the default-granted permission set in `browser/src/page/browser-session.ts`.

## Why
Without this, any site's request for the `local-network-access` permission is silently denied, with no prompt shown to the user. This breaks Okta FastPass / Okta Verify's device-bound authentication flow, which needs the browser to reach a local Okta Verify agent over loopback (via a real domain that resolves to `127.0.0.1`, e.g. `*.authenticatorlocalprod.com`) to complete a challenge-response. The failure surfaces to end users as "The browser is blocking communication with Okta Verify" with no actionable fix inside terminal-browser itself (no site-settings UI exists to grant it, unlike a full Chrome browser).

## Verified
Tested end-to-end against a live corporate Okta org's FastPass flow:
- Before: `CHROME_LOCAL_NETWORK_ACCESS_DENIED_ERROR`, sign-in blocked.
- After: the loopback challenge request succeeds (200), and SSO completes normally.

Note: on a freshly-launched process, the very first automatic FastPass attempt can still race the session's permission-handler setup and fail once; a reload after that resolves it. Might be worth a look separately if it's easy to fix (e.g. wiring `configureBrowserSession` before the first navigation starts), but it's an existing behavior unrelated to this specific change.

## One thing worth flagging
This grants `local-network-access` unconditionally to every site opened in terminal-browser, not just trusted ones — unlike the low-risk entries already in `GRANTED` (fullscreen, pointerLock, clipboard-sanitized-write, midi), this permission lets a page probe/reach devices and services on the user's local network, which is a more sensitive capability. I went with the minimal fix matching the existing pattern, but you may want something more scoped (an origin allowlist, or an actual permission prompt) instead of blanket-granting it. Happy to adjust if you'd rather go that route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)