### PR TITLE
fix: check live herdr graphics before launching a browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ In a local Herdr session, a browser pane can stay blank if Kitty graphics was
 enabled after the terminal client attached. This occurs with Herdr 0.8.2 even
 when the browser has loaded the page successfully.
 
+Before launching a browser, terminal-browser checks the live Herdr graphics
+state. If the attached client has no cell size, it reports the recovery steps
+below instead of opening a blank pane.
+
 Check `~/.config/herdr/config.toml` (or `HERDR_CONFIG_PATH` if set) for:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ terminal-browser ls # lists open browsers
 terminal-browser action # an agent-browser compatible cli for interacting with open terminal-browsers
 ```
 
+### Herdr: blank pane after setup
+
+In a local Herdr session, a browser pane can stay blank if Kitty graphics was
+enabled after the terminal client attached. This occurs with Herdr 0.8.2 even
+when the browser has loaded the page successfully.
+
+Check `~/.config/herdr/config.toml` (or `HERDR_CONFIG_PATH` if set) for:
+
+```toml
+[experimental]
+kitty_graphics = true
+```
+
+terminal-browser tries to enable this setting automatically. If you enabled it
+manually, run `herdr server reload-config`. Reloading the server configuration
+alone does not enable graphics in an already-attached client: detach with the
+default shortcut **Ctrl+B, then Q**, and run `herdr` from the outer shell to
+reattach. For a named session, use `herdr --session <name>` instead. Your panes
+and agents keep running during detach.
+
+This recovers the `cell_size_unavailable` error from `pane.graphics.info` when
+the client attached before graphics was enabled. See [issue #89](https://github.com/zenbu-labs/terminal-browser/issues/89)
+for other causes of blank panes, including remote sessions and unsupported host
+terminals.
+
 
 
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsc -p tsconfig.json && node --test \"test/*.test.js\""
   },
   "dependencies": {
     "pixel-store": "workspace:*",

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -21,6 +21,7 @@ import {
   cannotOpenPanes,
   checkTerminal,
   detect,
+  GRAPHICS_SKIP_ENV,
   unsupportedGraphicsMessage,
 } from "pixel-terminals";
 import type { Direction, Terminal, TerminalCheck } from "pixel-terminals";
@@ -474,6 +475,7 @@ async function newTabCommand(url: string | undefined, key: string | undefined): 
 }
 
 async function requireGraphics(check: TerminalCheck) {
+  if (!process.env[GRAPHICS_SKIP_ENV]) await check.terminal?.checkGraphics?.();
   if (check.graphics !== "unsupported") return;
   process.stderr.write(unsupportedGraphicsMessage(process.stderr.isTTY === true));
   process.exit(1);

--- a/cli/test/herdr-startup.test.js
+++ b/cli/test/herdr-startup.test.js
@@ -1,0 +1,122 @@
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+async function herdrSession(t, graphics) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tb-cli-"));
+  const socketPath = path.join(dir, "h.sock");
+  const configPath = path.join(dir, "config.toml");
+  const callsPath = path.join(dir, "calls.jsonl");
+  const bin = path.join(dir, "herdr");
+  fs.writeFileSync(configPath, "[experimental]\nkitty_graphics = true\n");
+  fs.writeFileSync(bin, `#!${process.execPath}
+const fs = require("node:fs");
+fs.appendFileSync(process.env.HERDR_TEST_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n");
+process.stderr.write("browser split requested\\n");
+process.exit(42);
+`, { mode: 0o755 });
+  const requests = [];
+  const server = net.createServer((socket) => {
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      if (!buffer.includes("\n")) return;
+      requests.push(JSON.parse(buffer.split("\n")[0]));
+      socket.end(JSON.stringify(graphics) + "\n");
+    });
+    socket.on("error", () => {});
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  return {
+    requests,
+    calls: () => fs.existsSync(callsPath) ? fs.readFileSync(callsPath, "utf8").trim().split("\n").map(JSON.parse) : [],
+    run: (args, extraEnv = {}) => new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [path.join(__dirname, "../dist/main.js"), ...args], {
+        env: {
+          PATH: process.env.PATH,
+          XDG_STATE_HOME: dir,
+          XDG_DATA_HOME: dir,
+          XDG_CACHE_HOME: dir,
+          XDG_RUNTIME_DIR: dir,
+          HERDR_PANE_ID: "w1:p1",
+          HERDR_TAB_ID: "w1:t1",
+          HERDR_CONFIG_PATH: configPath,
+          HERDR_SOCKET_PATH: socketPath,
+          HERDR_BIN_PATH: bin,
+          HERDR_TEST_CALLS: callsPath,
+          TERMINAL_BROWSER_NO_MERGE: "1",
+          ...extraEnv,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+      child.on("error", reject);
+      const timeout = setTimeout(() => {
+        child.kill();
+        reject(new Error("CLI did not exit"));
+      }, 5000);
+      child.on("close", (code) => {
+        clearTimeout(timeout);
+        resolve({ code, stdout, stderr });
+      });
+    }),
+  };
+}
+
+const NO_CELL_SIZE = { error: { code: "cell_size_unavailable", message: "host cell size is unavailable" } };
+
+for (const args of [["open", "https://example.com", "--split", "right"], ["new-tab", "https://example.com"]]) {
+  test(`${args[0]} explains reattachment before creating a blank browser pane`, async (t) => {
+    const session = await herdrSession(t, NO_CELL_SIZE);
+    const result = await session.run(args);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /host cell size is unavailable/);
+    assert.match(result.stderr, /Ctrl\+B.*Q/);
+    assert.deepEqual(session.calls(), []);
+    assert.equal(session.requests[0].method, "pane.graphics.info");
+  });
+}
+
+test("open proceeds to the requested split when Herdr graphics is ready", async (t) => {
+  const session = await herdrSession(t, { result: {
+    file_frame_transport: "direct-kitty",
+    file_frame_directory: "/tmp/frames",
+    cell_width_px: 16,
+    cell_height_px: 34,
+  } });
+  const result = await session.run(["open", "https://example.com", "--split", "right"]);
+  assert.match(result.stderr, /browser split requested/);
+  assert.equal(session.requests[0].method, "pane.graphics.info");
+  assert.deepEqual(session.calls()[0], ["pane", "split", "--pane", "w1:p1", "--direction", "right", "--focus", "--right-click", "pane"]);
+});
+
+test("ls stays available when the attached client cannot display graphics", async (t) => {
+  const session = await herdrSession(t, NO_CELL_SIZE);
+  const result = await session.run(["ls", "--json"]);
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout).browsers, []);
+  assert.deepEqual(session.requests, []);
+});
+
+test("the explicit graphics-check override still allows a launch attempt", async (t) => {
+  const session = await herdrSession(t, NO_CELL_SIZE);
+  const result = await session.run(["open", "https://example.com", "--split", "right"], {
+    TERMINAL_BROWSER_SKIP_GRAPHICS_CHECK: "1",
+  });
+  assert.match(result.stderr, /browser split requested/);
+  assert.deepEqual(session.requests, []);
+});

--- a/terminals/src/terminal.ts
+++ b/terminals/src/terminal.ts
@@ -45,6 +45,7 @@ export interface Terminal {
    * Allows code to be ran at startup, useful for preparing the terminal environment for terminal-browser
    */
   prepare?(): void | Promise<void>;
+  checkGraphics?(): void | Promise<void>;
   /**
    * Allows terminal-browser to know which pane its being called from inside the terminal.
    * This gives terminal-browser the ability to know if a terminal-browser instance

--- a/terminals/src/terminals/herdr.ts
+++ b/terminals/src/terminals/herdr.ts
@@ -21,6 +21,19 @@ interface HerdrProcessInfo {
   foreground_processes?: { cmdline?: string }[];
 }
 
+interface HerdrGraphicsInfo {
+  file_frame_transport?: string;
+  file_frame_directory?: string;
+  cell_width_px?: number;
+  cell_height_px?: number;
+}
+
+class HerdrError extends Error {
+  constructor(message: string, readonly code?: string) {
+    super(message);
+  }
+}
+
 function herdrConfigPath(env: NodeJS.ProcessEnv): string {
   if (env.HERDR_CONFIG_PATH) return env.HERDR_CONFIG_PATH;
   if (process.platform === "win32") {
@@ -58,14 +71,41 @@ export const herdr: Detect = (env, run) => {
   }
 
   async function prepare(): Promise<void> {
+    const configPath = herdrConfigPath(env);
+    const current = fs.existsSync(configPath) ? fs.readFileSync(configPath, "utf8") : "";
+    if (/^[ \t]*kitty_graphics[ \t]*=[ \t]*true[ \t]*$/m.test(current)) return;
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, enableKittyGraphics(current));
+    const reply = JSON.parse(await herdr(["server", "reload-config"])) as {
+      error?: { message?: string };
+      result?: { status?: string; diagnostics?: string[] };
+    };
+    if (reply.error || reply.result?.status !== "applied") {
+      const reason = reply.error?.message || reply.result?.diagnostics?.join("; ") || "configuration was not applied";
+      throw new Error(`Could not enable Herdr graphics: ${reason}`);
+    }
+  }
+
+  async function checkGraphics(): Promise<void> {
+    let info: HerdrGraphicsInfo | undefined;
     try {
-      const configPath = herdrConfigPath(env);
-      const current = fs.existsSync(configPath) ? fs.readFileSync(configPath, "utf8") : "";
-      if (/^[ \t]*kitty_graphics[ \t]*=[ \t]*true[ \t]*$/m.test(current)) return;
-      fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.writeFileSync(configPath, enableKittyGraphics(current));
-      await herdr(["server", "reload-config"]);
-    } catch {
+      info = await socketCall("pane.graphics.info", { pane_id: env.HERDR_PANE_ID }) as HerdrGraphicsInfo | undefined;
+    } catch (error) {
+      if (error instanceof HerdrError && error.code === "cell_size_unavailable") {
+        throw new Error(
+          `Herdr: ${error.message}. Detach with Ctrl+B, then Q (the default shortcut), and run herdr again from the outer shell (herdr --session <name> for a named session). Your panes and agents keep running.`,
+        );
+      }
+      throw error;
+    }
+    if (info?.file_frame_transport !== "direct-kitty") {
+      throw new Error("Herdr is not offering direct graphics. Use a local session in Ghostty, Kitty or WezTerm with only one attached client.");
+    }
+    if (typeof info.file_frame_directory !== "string" || !info.file_frame_directory) {
+      throw new Error("Herdr did not provide a graphics frame directory.");
+    }
+    if (![info.cell_width_px, info.cell_height_px].every((size) => typeof size === "number" && Number.isInteger(size) && size > 0)) {
+      throw new Error("Herdr reported invalid terminal cell dimensions.");
     }
   }
 
@@ -113,14 +153,19 @@ export const herdr: Detect = (env, run) => {
       let buffer = "";
       socket.setTimeout(5000, () => socket.destroy(new Error("herdr socket timed out")));
       socket.on("error", reject);
+      socket.on("close", () => reject(new Error("herdr closed the socket without a reply")));
       socket.on("data", (chunk) => {
         buffer += chunk.toString();
         const line = buffer.indexOf("\n");
         if (line < 0) return;
-        socket.end();
-        const reply = JSON.parse(buffer.slice(0, line)) as { error?: { message?: string }; result?: unknown };
-        if (reply.error) reject(new Error(reply.error.message ?? "herdr socket call failed"));
-        else resolve(reply.result);
+        socket.destroy();
+        try {
+          const reply = JSON.parse(buffer.slice(0, line)) as { error?: { message?: string; code?: string }; result?: unknown };
+          if (reply.error) reject(new HerdrError(reply.error.message ?? "herdr socket call failed", reply.error.code));
+          else resolve(reply.result);
+        } catch {
+          reject(new Error("Herdr returned an invalid JSON response"));
+        }
       });
       socket.on("connect", () => {
         socket.write(`${JSON.stringify({ id: "terminal-browser", method, params })}\n`);
@@ -137,6 +182,7 @@ export const herdr: Detect = (env, run) => {
   return {
     name: "herdr",
     prepare,
+    checkGraphics,
     getCurrentPane: async () => ({ id: env.HERDR_PANE_ID!, tab: env.HERDR_TAB_ID! }),
     listPanes,
     async sendText(pane, text) {

--- a/terminals/test/terminals.test.js
+++ b/terminals/test/terminals.test.js
@@ -1,6 +1,7 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
+const net = require("node:net");
 const path = require("node:path");
 const { test } = require("node:test");
 
@@ -178,7 +179,7 @@ test("herdr prepare leaves an already-enabled config alone and never reloads", a
   assert.deepEqual(commands, []);
 });
 
-test("herdr prepare stays silent when reload-config rejects the edit", async () => {
+test("herdr prepare reports reload-config diagnostics", async () => {
   const configPath = tempHerdrConfig(null);
   const env = { HERDR_PANE_ID: "w1:p1", HERDR_CONFIG_PATH: configPath };
   const { run } = recorder({
@@ -186,31 +187,104 @@ test("herdr prepare stays silent when reload-config rejects the edit", async () 
       result: { status: "failed", diagnostics: ["config parse error"] },
     }),
   });
-  const originalError = console.error;
-  const warnings = [];
-  console.error = (message) => warnings.push(message);
-  try {
-    await assert.doesNotReject(detect(env, run).prepare());
-  } finally {
-    console.error = originalError;
-  }
-  assert.deepEqual(warnings, []);
+  await assert.rejects(detect(env, run).prepare(), /config parse error/);
 });
 
-test("herdr prepare stays silent when herdr itself cannot be run", async () => {
+test("herdr prepare preserves the error when herdr cannot be run", async () => {
   const configPath = tempHerdrConfig(null);
   const env = { HERDR_PANE_ID: "w1:p1", HERDR_CONFIG_PATH: configPath };
-  const run = async () => {
-    throw new Error("spawn herdr ENOENT");
-  };
-  const originalError = console.error;
-  const warnings = [];
-  console.error = (message) => warnings.push(message);
-  try {
-    await assert.doesNotReject(detect(env, run).prepare());
-  } finally {
-    console.error = originalError;
-  }
-  assert.deepEqual(warnings, []);
+  const error = new Error("spawn herdr ENOENT");
+  await assert.rejects(detect(env, async () => { throw error; }).prepare(), (caught) => caught === error);
 });
 
+test("herdr prepare preserves config read failures", async (t) => {
+  const configPath = tempHerdrConfig(null);
+  fs.mkdirSync(configPath);
+  t.after(() => fs.rmSync(path.dirname(configPath), { recursive: true, force: true }));
+  const env = { HERDR_PANE_ID: "w1:p1", HERDR_CONFIG_PATH: configPath };
+  await assert.rejects(detect(env, async () => "").prepare(), { code: "EISDIR" });
+});
+
+async function herdrSocket(t, reply) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "herdr-sock-"));
+  const socketPath = path.join(dir, "h.sock");
+  const requests = [];
+  const server = net.createServer((socket) => {
+    socket.on("error", () => {});
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      if (!buffer.includes("\n")) return;
+      requests.push(JSON.parse(buffer.split("\n")[0]));
+      if (reply === null) socket.end();
+      else socket.end(typeof reply === "string" ? reply : JSON.stringify(reply) + "\n");
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const terminal = detect({ HERDR_PANE_ID: "w1:p7", HERDR_SOCKET_PATH: socketPath }, async () => "");
+  return { terminal, requests };
+}
+
+const READY_GRAPHICS = {
+  file_frame_transport: "direct-kitty",
+  file_frame_directory: "/tmp/herdr-frames",
+  cell_width_px: 16,
+  cell_height_px: 34,
+};
+
+test("herdr graphics check explains reattachment when the live client has no cell size", async (t) => {
+  const { terminal, requests } = await herdrSocket(t, {
+    error: { code: "cell_size_unavailable", message: "host cell size is unavailable" },
+  });
+  await assert.rejects(terminal.checkGraphics(), (error) => {
+    assert.match(error.message, /host cell size is unavailable/);
+    assert.match(error.message, /Ctrl\+B.*Q/);
+    assert.match(error.message, /herdr --session/);
+    return true;
+  });
+  assert.equal(requests[0].method, "pane.graphics.info");
+  assert.deepEqual(requests[0].params, { pane_id: "w1:p7" });
+});
+
+test("herdr graphics check accepts the live direct transport", async (t) => {
+  const { terminal } = await herdrSocket(t, { result: READY_GRAPHICS });
+  await assert.doesNotReject(terminal.checkGraphics());
+});
+
+test("herdr graphics check preserves other server errors", async (t) => {
+  const { terminal } = await herdrSocket(t, {
+    error: { code: "pane_not_found", message: "no such pane w1:p7" },
+  });
+  await assert.rejects(terminal.checkGraphics(), (error) => {
+    assert.match(error.message, /no such pane w1:p7/);
+    assert.doesNotMatch(error.message, /reattach/i);
+    return true;
+  });
+});
+
+for (const [name, result] of [
+  ["missing transport", { ...READY_GRAPHICS, file_frame_transport: undefined }],
+  ["unsupported transport", { ...READY_GRAPHICS, file_frame_transport: "inline" }],
+  ["missing frame directory", { ...READY_GRAPHICS, file_frame_directory: undefined }],
+  ["zero cell width", { ...READY_GRAPHICS, cell_width_px: 0 }],
+  ["missing cell height", { ...READY_GRAPHICS, cell_height_px: undefined }],
+]) {
+  test(`herdr graphics check rejects ${name}`, async (t) => {
+    const { terminal } = await herdrSocket(t, { result });
+    await assert.rejects(terminal.checkGraphics(), /Herdr/);
+  });
+}
+
+for (const [name, reply] of [["malformed reply", "not json\n"], ["closed socket", null]]) {
+  test(`herdr graphics check reports a ${name}`, async (t) => {
+    const { terminal } = await herdrSocket(t, reply);
+    await assert.rejects(terminal.checkGraphics());
+  });
+}


### PR DESCRIPTION
After installing, I've opened a browser but the screen was blank. I've tried to run a command to open a specific webpage but result was same. This made me try to relod config which also did not helped. Only detach and run herdr as a last resort solution made it work properly

Related: #89
